### PR TITLE
[ISSUE - #231] TanStack Query 전역 캐시/무효화 정책 정비

### DIFF
--- a/docs/개발일지/2026-02-24.md
+++ b/docs/개발일지/2026-02-24.md
@@ -1,0 +1,254 @@
+# 2026-02-24 개발일지
+
+## 주제
+
+TanStack Query 기반 서버 상태 최적화, BFF/클라이언트 계측 도입, 추천 API 안정화 캐시 적용
+
+---
+
+## 1) 배경
+
+- 개인정보 수정 후 화면 즉시 반영이 되지 않고 새로고침이 필요한 이슈가 발생했다.
+- 팀 내에서 "감"이 아닌 "실제 수치"로 캐싱 우선순위를 판단할 필요가 있었다.
+- 메인 진입 시 추천 API가 반복 호출되고 실패율이 높아 사용자 체감 품질에 영향이 있었다.
+
+---
+
+## 2) 오늘 목표
+
+- 프로필 수정 후 `user/me` 캐시를 즉시 동기화한다.
+- API 호출 계측(호출 수/중복률/응답시간/p95/30초 내 재호출률)을 개발 환경에서 확인 가능하게 만든다.
+- 실제 계측 결과를 기반으로 TanStack Query 캐싱 우선순위를 적용한다.
+- 우선순위 높은 영역(`resumes`, `reports`, `onboarding metadata`, `users/me`)에 캐시 정책을 반영한다.
+- 추천 API는 TanStack Query가 아닌 BFF 레벨 캐시로 중복 호출을 줄인다.
+
+---
+
+## 3) 구현 작업 상세
+
+## 3-1. 개인정보 수정 즉시 반영
+
+파일:
+
+- `src/features/me/model/useMyPageEditSubmit.client.ts`
+
+적용:
+
+- 프로필 수정 성공 후 `queryClient.setQueryData(['user','me'])`로 즉시 캐시 반영
+- 이어서 `invalidateQueries(['user','me'])`로 백그라운드 재검증
+
+효과:
+
+- `/me` 복귀 시 stale 데이터 노출 가능성을 줄이고, 새로고침 의존도를 해소
+
+---
+
+## 3-2. 클라이언트 API 계측 도입
+
+파일:
+
+- `src/shared/metrics/apiMetricsTracker.ts` (신규)
+- `src/shared/api/apiFetch.ts`
+- `src/shared/metrics/index.ts`
+
+수집 지표:
+
+- endpoint별 호출 수
+- duplicateRate
+- rehitWithin30sRate
+- avgMs, p95Ms
+- errorRate
+
+정책:
+
+- 개발환경 + `NEXT_PUBLIC_API_METRICS=1`일 때만 동작
+- URL 정규화(숫자 ID/UUID 치환, 일부 쿼리 파라미터만 유지)
+- endpoint당 샘플 개수 제한(메모리 상한)
+- 주기적 테이블 출력
+
+디버그 편의:
+
+- `window.__apiMetricsPrint()` 수동 출력 훅 제공
+- `window.__apiMetricsReset()` 초기화 훅 제공
+
+---
+
+## 3-3. 서버(BFF) 계측 도입
+
+파일:
+
+- `src/shared/metrics/serverApiMetricsTracker.ts` (신규)
+- `src/app/bff/_lib/fetchUpstream.ts`
+
+적용:
+
+- BFF upstream fetch 경로에서 서버 로그용 집계
+- timeout/5xx 케이스 포함
+- 터미널에서 `[SERVER API Metrics]` + `console.table`로 확인 가능
+
+목적:
+
+- 브라우저 계측과 별도로 SSR/BFF 경로 중복 호출을 관찰
+
+---
+
+## 3-4. 전문가 추천 API(BFF) 단기 캐시
+
+파일:
+
+- `src/app/bff/experts/recommendations/route.ts`
+
+적용:
+
+- 사용자별(`accessToken + query`) in-memory 캐시
+- fresh TTL: 30초
+- stale-if-error: 최대 5분
+- cache 상태 헤더:
+  - `x-recommendations-cache: HIT`
+  - `x-recommendations-cache: STALE_FALLBACK`
+
+의도:
+
+- 메인 재진입 시 추천 API 중복 호출 억제
+- 업스트림 장애 시 홈 렌더 품질 보호
+
+---
+
+## 3-5. `resumes` TanStack Query 전환
+
+파일:
+
+- `src/entities/resumes/model/useResumesQuery.client.ts` (신규)
+- `src/entities/resumes/index.ts`
+- `src/features/resume/model/useResumeList.client.ts`
+- `src/features/expert/model/useExpertResumes.client.ts`
+- `src/features/resume/model/useResumeSubmit.client.ts`
+
+적용:
+
+- 공통 query key: `['resumes']`
+- 캐시 옵션: `staleTime 30s`, `gcTime 10m`
+- `useResumeList`/`useExpertResumes`가 동일 캐시 공유
+- 삭제 시 `setQueryData`로 즉시 목록 반영
+- 생성/수정 후 `invalidateQueries(['resumes'])`로 동기화
+
+---
+
+## 3-6. `reports` TanStack Query 전환
+
+파일:
+
+- `src/entities/reports/model/useReportsQuery.client.ts` (신규)
+- `src/entities/reports/index.ts`
+- `src/features/report/model/useReportList.client.ts`
+
+적용:
+
+- 공통 query key: `['reports']`
+- 캐시 옵션: `staleTime 30s`, `gcTime 10m`
+- 삭제 시 `setQueryData`로 즉시 목록 반영
+
+---
+
+## 3-7. 온보딩 메타데이터 단일 캐시 통합
+
+파일:
+
+- `src/features/onboarding/model/useOnboardingMetadataQuery.client.ts` (신규)
+- `src/features/onboarding/index.ts`
+- `src/features/onboarding/model/useOnboardingReferenceData.client.ts`
+- `src/features/me/model/useMyPageEditReferenceData.client.ts`
+
+적용:
+
+- 기존 분리 호출(`jobs`, `career-levels`, `skills`)을 단일 `metadata` 쿼리로 통합
+- query key: `['onboarding','metadata']`
+- 캐시 옵션: `staleTime 1h`, `gcTime 24h`
+- 포커스/재연결 자동 리패치 비활성화
+- 온보딩/마이페이지 수정 화면에서 동일 캐시 재사용
+
+---
+
+## 3-8. `users/me` 재요청 정책 최적화
+
+파일:
+
+- `src/entities/user/model/useUserMeQuery.client.ts`
+
+변경:
+
+- `staleTime: 30s -> 5m`
+- `gcTime: 30m` 추가
+- `refetchOnWindowFocus: false`
+- `refetchOnReconnect: false`
+
+효과:
+
+- 페이지 이동/포커스 복귀 시 불필요한 `users/me` 재요청 감소
+
+---
+
+## 4) 계측 결과 해석 (오늘 세션 기준)
+
+핵심 관찰:
+
+- 온보딩 참조 데이터(`jobs`, `career-levels`, `skills`) 반복 호출이 캐시 적용 후 크게 감소
+- `users/me` 중복 호출률 개선
+- `resumes`, `reports`는 화면 간 재진입 시 캐시 공유로 구조적 중복 완화
+- `experts/recommendations`는 캐시 적용 전/후를 떠나 업스트림 실패율 자체가 높아 백엔드 안정화가 병행 필요
+
+주의:
+
+- `GET /resume`, `GET /report` 로그는 페이지 라우트 요청이며 데이터 API 호출(`GET /bff/resumes`, `GET /bff/reports`)과 별개
+
+---
+
+## 5) 측정 도구 및 지표 기준
+
+## 5-1. 측정 도구 구성
+
+| 구분 | 파일 | 활성화 조건 | 출력 위치 | 목적 |
+| --- | --- | --- | --- | --- |
+| 클라이언트 계측 | `src/shared/metrics/apiMetricsTracker.ts` + `src/shared/api/apiFetch.ts` | `NODE_ENV=development` + `NEXT_PUBLIC_API_METRICS=1` | 브라우저 콘솔 | CSR/API 중복 호출 및 응답 시간 확인 |
+| 서버 계측 | `src/shared/metrics/serverApiMetricsTracker.ts` + `src/app/bff/_lib/fetchUpstream.ts` | `NODE_ENV=development` + `API_METRICS_SERVER=1` | 서버 터미널 로그 | SSR/BFF upstream 호출 패턴 및 장애 관찰 |
+| 수동 디버그 | `window.__apiMetricsPrint()`, `window.__apiMetricsReset()` | 클라이언트 계측 활성화 시 | 브라우저 콘솔 | 즉시 출력/세션 리셋 |
+
+## 5-2. 수치 계산 기준
+
+| 지표 | 의미 | 계산식/기준 |
+| --- | --- | --- |
+| `calls` | endpoint 총 호출 수 | endpoint key별 누적 요청 수 |
+| `duplicateRate` | 중복 호출 비율 | `duplicateCalls / calls` |
+| `rehitWithin30sRate` | 30초 내 재호출 비율 | 인접 호출 간격 `< 30,000ms` 인 건수 / `max(1, calls-1)` |
+| `avgMs` | 평균 응답 시간 | `totalDurationMs / calls` |
+| `p95Ms` | 95퍼센타일 응답 시간 | 정렬 후 `ceil(0.95*n)-1` 인덱스 값 |
+| `errorRate` | 오류 비율 | `(status >= 400 or status=0) 건수 / calls` |
+
+보조 기준:
+
+- 중복 판단 윈도우: `30초`
+- 샘플 상한: endpoint당 최근 `200개`
+- 클라이언트 URL 정규화: 숫자 path/UUID 치환, query는 `cursor/page/size/limit`만 유지
+- 서버 path 정규화: 숫자 path/UUID 치환, query는 `cursor/page/size/limit/status`만 유지
+
+---
+
+## 6) 오늘 커밋(작업 단위 분할)
+
+1. `feat: 클라이언트 API 계측 로깅 추가`
+2. `feat: 서버 API 메트릭 집계 로그 추가`
+3. `feat: API 계측 디버그 출력 훅 추가`
+4. `feat: 전문가 추천 사용자별 단기 캐시 적용`
+5. `feat: 이력서 목록 쿼리 캐시 공유 적용`
+6. `feat: 리포트 목록 쿼리 캐시 공유 적용`
+7. `feat: 온보딩 메타데이터 공통 쿼리 캐시 적용`
+8. `feat: 사용자 정보 쿼리 재요청 정책 최적화`
+
+---
+
+## 7) 후속 TODO
+
+- `experts/recommendations` 업스트림 5xx 원인 분석 및 안정화(타임아웃/재시도/회로차단 정책)
+- `notifications` 400 응답 반복 이슈 원인 점검(인증/요청 계약)
+- 계측 기반 ROI 점수 산출 자동화(엔드포인트별 우선순위 보고)
+- BFF 캐시 정책 문서화(TTL, stale 전략, 무효화 규칙)

--- a/src/app/bff/_lib/fetchUpstream.ts
+++ b/src/app/bff/_lib/fetchUpstream.ts
@@ -1,4 +1,5 @@
 import { withTimeout, RequestTimeoutError } from '@/shared/api/server';
+import { trackServerApiRequest } from '@/shared/metrics/serverApiMetricsTracker';
 
 type TimeoutProfile = 'optional' | 'default' | 'critical';
 
@@ -74,6 +75,12 @@ export async function fetchBffUpstream(
       timeoutMs,
       signal: requestSignal,
     });
+    trackServerApiRequest({
+      path: bffPath ?? upstreamPath,
+      method,
+      status: res.status,
+      durationMs: Date.now() - startMs,
+    });
 
     if (res.status >= 500) {
       console.error('[BFF_UPSTREAM_HTTP_ERROR]', {
@@ -92,6 +99,12 @@ export async function fetchBffUpstream(
   } catch (error) {
     if (error instanceof RequestTimeoutError) {
       const requestId = crypto.randomUUID();
+      trackServerApiRequest({
+        path: bffPath ?? upstreamPath,
+        method,
+        status: 504,
+        durationMs: Date.now() - startMs,
+      });
       console.error('[BFF_UPSTREAM_TIMEOUT]', {
         event: 'bff_upstream_timeout',
         bffPath: bffPath ?? upstreamPath,

--- a/src/app/bff/experts/recommendations/route.ts
+++ b/src/app/bff/experts/recommendations/route.ts
@@ -5,6 +5,16 @@ import { BusinessError, type ApiResponse, buildApiUrl } from '@/shared/api';
 import { fetchBffUpstream } from '@/app/bff/_lib/fetchUpstream';
 
 const RECOMMENDATIONS_PATH = '/api/v1/experts/recommendations';
+const RECOMMENDATIONS_CACHE_TTL_MS = 30_000;
+const RECOMMENDATIONS_STALE_IF_ERROR_MS = 5 * 60_000;
+const MAX_CACHE_ENTRIES = 500;
+
+type CachedRecommendation = {
+  cachedAt: number;
+  body: unknown;
+};
+
+const recommendationsCache = new Map<string, CachedRecommendation>();
 
 function getAccessToken(req: Request, cookieToken?: string) {
   const authHeader = req.headers.get('authorization');
@@ -12,6 +22,28 @@ function getAccessToken(req: Request, cookieToken?: string) {
     ? authHeader.slice(7)
     : (authHeader ?? undefined);
   return rawToken?.trim() || cookieToken?.trim() || undefined;
+}
+
+function buildCacheKey(accessToken: string | undefined, query: string) {
+  return `${accessToken ?? 'guest'}::${query || 'top_k=12'}`;
+}
+
+function getCachedRecommendation(
+  cacheKey: string,
+  maxAgeMs: number,
+): { hit: boolean; body: unknown | null } {
+  const cached = recommendationsCache.get(cacheKey);
+  if (!cached) return { hit: false, body: null };
+  if (Date.now() - cached.cachedAt > maxAgeMs) return { hit: false, body: null };
+  return { hit: true, body: cached.body };
+}
+
+function setCachedRecommendation(cacheKey: string, body: unknown) {
+  if (recommendationsCache.size >= MAX_CACHE_ENTRIES) {
+    const firstKey = recommendationsCache.keys().next().value;
+    if (typeof firstKey === 'string') recommendationsCache.delete(firstKey);
+  }
+  recommendationsCache.set(cacheKey, { cachedAt: Date.now(), body });
 }
 
 export const dynamic = 'force-dynamic';
@@ -24,6 +56,13 @@ export async function GET(req: Request) {
 
     const url = new URL(req.url);
     const query = url.search ? url.search : '';
+    const cacheKey = buildCacheKey(accessToken, query);
+    const freshCache = getCachedRecommendation(cacheKey, RECOMMENDATIONS_CACHE_TTL_MS);
+    if (freshCache.hit) {
+      return NextResponse.json(freshCache.body, {
+        headers: { 'x-recommendations-cache': 'HIT' },
+      });
+    }
 
     const res = await fetchBffUpstream(buildApiUrl(`${RECOMMENDATIONS_PATH}${query}`), {
       timeoutMs: 20000,
@@ -33,6 +72,12 @@ export async function GET(req: Request) {
 
     const body = await res.json().catch(() => null);
     if (!res.ok) {
+      const staleCache = getCachedRecommendation(cacheKey, RECOMMENDATIONS_STALE_IF_ERROR_MS);
+      if (staleCache.hit) {
+        return NextResponse.json(staleCache.body, {
+          headers: { 'x-recommendations-cache': 'STALE_FALLBACK' },
+        });
+      }
       if (body && typeof body.code === 'string') {
         const response: ApiResponse<unknown> = {
           code: body.code,
@@ -49,6 +94,7 @@ export async function GET(req: Request) {
       return NextResponse.json(response, { status: res.status });
     }
 
+    setCachedRecommendation(cacheKey, body ?? { code: 'OK', message: 'success', data: null });
     return NextResponse.json(body ?? { code: 'OK', message: 'success', data: null });
   } catch (error) {
     if (error instanceof BusinessError) {

--- a/src/entities/reports/index.ts
+++ b/src/entities/reports/index.ts
@@ -3,3 +3,4 @@ export type { ReportSummary, ReportsListData } from './api/getReports';
 export { getReportDetail } from './api/getReportDetail';
 export type { ReportDetail } from './api/getReportDetail';
 export { deleteReport } from './api/deleteReport';
+export { useReportsQuery, reportsQueryKey } from './model/useReportsQuery.client';

--- a/src/entities/reports/model/useReportsQuery.client.ts
+++ b/src/entities/reports/model/useReportsQuery.client.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { getReports } from '../api/getReports';
+
+export const reportsQueryKey = ['reports'] as const;
+
+type UseReportsQueryOptions = {
+  enabled?: boolean;
+};
+
+export function useReportsQuery(options: UseReportsQueryOptions = {}) {
+  const { enabled = true } = options;
+
+  return useQuery({
+    queryKey: reportsQueryKey,
+    queryFn: getReports,
+    enabled,
+    staleTime: 30_000,
+    gcTime: 10 * 60_000,
+  });
+}

--- a/src/entities/resumes/index.ts
+++ b/src/entities/resumes/index.ts
@@ -5,6 +5,7 @@ export { deleteResume } from './api/deleteResume';
 export { updateResumeTitle } from './api/updateResumeTitle';
 export { updateResume } from './api/updateResume';
 export { parseResumeSync } from './api/parseResumeSync';
+export { useResumesQuery, resumesQueryKey } from './model/useResumesQuery.client';
 export type { Resume, ResumesResponse } from './api/getResumes';
 export type { CreateResumePayload, CreateResumeResponse } from './api/createResume';
 export type { ResumeDetail } from './api/getResumeDetail';

--- a/src/entities/resumes/model/useResumesQuery.client.ts
+++ b/src/entities/resumes/model/useResumesQuery.client.ts
@@ -1,0 +1,23 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { getResumes } from '../api/getResumes';
+
+export const resumesQueryKey = ['resumes'] as const;
+
+type UseResumesQueryOptions = {
+  enabled?: boolean;
+};
+
+export function useResumesQuery(options: UseResumesQueryOptions = {}) {
+  const { enabled = true } = options;
+
+  return useQuery({
+    queryKey: resumesQueryKey,
+    queryFn: getResumes,
+    enabled,
+    staleTime: 30_000,
+    gcTime: 10 * 60_000,
+  });
+}

--- a/src/entities/user/model/useUserMeQuery.client.ts
+++ b/src/entities/user/model/useUserMeQuery.client.ts
@@ -14,6 +14,9 @@ export function useUserMeQuery(options: UseUserMeQueryOptions = {}) {
     queryKey: ['user', 'me'],
     queryFn: getUserMe,
     enabled,
-    staleTime: 30_000,
+    staleTime: 5 * 60_000,
+    gcTime: 30 * 60_000,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
   });
 }

--- a/src/features/expert/model/useExpertResumes.client.ts
+++ b/src/features/expert/model/useExpertResumes.client.ts
@@ -2,7 +2,7 @@
 
 import { useEffect, useState } from 'react';
 
-import { getResumes, type Resume } from '@/entities/resumes';
+import { useResumesQuery, type Resume } from '@/entities/resumes';
 import { HttpError } from '@/shared/api';
 
 export function useExpertResumes(authStatus: 'checking' | 'authed' | 'guest') {
@@ -10,41 +10,38 @@ export function useExpertResumes(authStatus: 'checking' | 'authed' | 'guest') {
   const [resumeError, setResumeError] = useState('');
   const [isLoadingResumes, setIsLoadingResumes] = useState(false);
   const [selectedResumeId, setSelectedResumeId] = useState<number | null>(null);
+  const { data, error, isLoading } = useResumesQuery({ enabled: authStatus === 'authed' });
 
   useEffect(() => {
     if (authStatus !== 'authed') {
       setResumes([]);
+      setResumeError('');
+      setIsLoadingResumes(false);
       setSelectedResumeId(null);
       return;
     }
 
-    let cancelled = false;
-    setIsLoadingResumes(true);
-    setResumeError('');
+    setResumes(data?.resumes ?? []);
+    setIsLoadingResumes(isLoading);
+  }, [authStatus, data, isLoading]);
 
-    (async () => {
-      try {
-        const data = await getResumes();
-        if (cancelled) return;
-        setResumes(data.resumes);
-      } catch (error) {
-        if (cancelled) return;
-        if (error instanceof HttpError && error.status === 401) {
-          setResumeError('로그인 이후에 사용 가능합니다.');
-        } else {
-          setResumeError(error instanceof Error ? error.message : '이력서를 불러오지 못했습니다.');
-        }
-        setResumes([]);
-      } finally {
-        if (cancelled) return;
-        setIsLoadingResumes(false);
-      }
-    })();
+  useEffect(() => {
+    if (!error) {
+      setResumeError('');
+      return;
+    }
+    if (error instanceof HttpError && error.status === 401) {
+      setResumeError('로그인 이후에 사용 가능합니다.');
+      return;
+    }
+    setResumeError(error instanceof Error ? error.message : '이력서를 불러오지 못했습니다.');
+  }, [error]);
 
-    return () => {
-      cancelled = true;
-    };
-  }, [authStatus]);
+  useEffect(() => {
+    if (selectedResumeId === null) return;
+    if (resumes.some((resume) => resume.resumeId === selectedResumeId)) return;
+    setSelectedResumeId(null);
+  }, [resumes, selectedResumeId]);
 
   return {
     resumes,

--- a/src/features/me/model/useMyPageEditReferenceData.client.ts
+++ b/src/features/me/model/useMyPageEditReferenceData.client.ts
@@ -1,96 +1,44 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import type { CareerLevel, Job, Skill } from '@/entities/onboarding';
-import { getCareerLevels, getJobs, getSkills } from '@/features/onboarding';
+import { useOnboardingMetadataQuery } from '@/features/onboarding';
 import { useCommonApiErrorHandler } from '@/shared/api';
 
 export function useMyPageEditReferenceData() {
   const handleCommonApiError = useCommonApiErrorHandler();
-  const [jobs, setJobs] = useState<Job[]>([]);
-  const [careerLevels, setCareerLevels] = useState<CareerLevel[]>([]);
-  const [skills, setSkills] = useState<Skill[]>([]);
-  const [jobsLoading, setJobsLoading] = useState(true);
-  const [careerLoading, setCareerLoading] = useState(true);
-  const [skillsLoading, setSkillsLoading] = useState(true);
   const [jobsError, setJobsError] = useState<string | null>(null);
   const [careerError, setCareerError] = useState<string | null>(null);
   const [skillsError, setSkillsError] = useState<string | null>(null);
+  const { data, error, isLoading } = useOnboardingMetadataQuery();
 
   useEffect(() => {
-    let mounted = true;
-    getJobs()
-      .then((data) => {
-        if (!mounted) return;
-        setJobs(data.jobs);
-      })
-      .catch(async (error) => {
-        if (!mounted) return;
-        if (await handleCommonApiError(error)) return;
-        setJobsError(error instanceof Error ? error.message : '직무 목록을 불러오지 못했습니다.');
-      })
-      .finally(() => {
-        if (!mounted) return;
-        setJobsLoading(false);
-      });
+    if (!error) {
+      setJobsError(null);
+      setCareerError(null);
+      setSkillsError(null);
+      return;
+    }
+    (async () => {
+      if (await handleCommonApiError(error)) return;
+      const message = error instanceof Error ? error.message : '참조 데이터를 불러오지 못했습니다.';
+      setJobsError(message);
+      setCareerError(message);
+      setSkillsError(message);
+    })();
+  }, [error, handleCommonApiError]);
 
-    return () => {
-      mounted = false;
-    };
-  }, [handleCommonApiError]);
-
-  useEffect(() => {
-    let mounted = true;
-    getCareerLevels()
-      .then((data) => {
-        if (!mounted) return;
-        setCareerLevels(data.career_levels);
-      })
-      .catch(async (error) => {
-        if (!mounted) return;
-        if (await handleCommonApiError(error)) return;
-        setCareerError(error instanceof Error ? error.message : '경력 목록을 불러오지 못했습니다.');
-      })
-      .finally(() => {
-        if (!mounted) return;
-        setCareerLoading(false);
-      });
-
-    return () => {
-      mounted = false;
-    };
-  }, [handleCommonApiError]);
-
-  useEffect(() => {
-    let mounted = true;
-    getSkills()
-      .then((data) => {
-        if (!mounted) return;
-        setSkills(data.skills);
-      })
-      .catch(async (error) => {
-        if (!mounted) return;
-        if (await handleCommonApiError(error)) return;
-        setSkillsError(error instanceof Error ? error.message : '기술 목록을 불러오지 못했습니다.');
-      })
-      .finally(() => {
-        if (!mounted) return;
-        setSkillsLoading(false);
-      });
-
-    return () => {
-      mounted = false;
-    };
-  }, [handleCommonApiError]);
+  const jobs = useMemo(() => data?.jobs ?? [], [data]);
+  const careerLevels = useMemo(() => data?.career_levels ?? [], [data]);
+  const skills = useMemo(() => data?.skills ?? [], [data]);
 
   return {
     jobs,
     careerLevels,
     skills,
-    jobsLoading,
-    careerLoading,
-    skillsLoading,
+    jobsLoading: isLoading,
+    careerLoading: isLoading,
+    skillsLoading: isLoading,
     jobsError,
     careerError,
     skillsError,

--- a/src/features/me/model/useMyPageEditSubmit.client.ts
+++ b/src/features/me/model/useMyPageEditSubmit.client.ts
@@ -2,11 +2,13 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { deleteProfileImage, updateUserMe } from '@/features/me';
 import { createPresignedUrl, uploadToPresignedUrl } from '@/features/uploads';
 import { useCommonApiErrorHandler } from '@/shared/api';
 import { useToast } from '@/shared/ui/toast';
+import type { UserMe } from '@/entities/user';
 import type { CareerLevel, Job, Skill } from '@/entities/onboarding';
 
 const updateErrorMessages: Record<string, string> = {
@@ -62,6 +64,7 @@ export function useMyPageEditSubmit({
   setSubmitError,
 }: UseMyPageEditSubmitParams) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const handleCommonApiError = useCommonApiErrorHandler();
   const { pushToast } = useToast();
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -134,7 +137,7 @@ export function useMyPageEditSubmit({
         setProfileImageUrl(null);
       }
 
-      await updateUserMe({
+      const updatedUser = await updateUserMe({
         nickname: trimmed,
         introduction: introduction.trim(),
         career_level_id: selectedCareer.id,
@@ -143,6 +146,8 @@ export function useMyPageEditSubmit({
         profile_image_url: uploadedImageUrl,
       });
 
+      queryClient.setQueryData<UserMe | null>(['user', 'me'], updatedUser);
+      await queryClient.invalidateQueries({ queryKey: ['user', 'me'] });
       router.replace('/me');
     } catch (error: unknown) {
       if (await handleCommonApiError(error)) return;

--- a/src/features/notification-fcm/index.ts
+++ b/src/features/notification-fcm/index.ts
@@ -1,2 +1,6 @@
-export { useFcmLifecycle, removeRegisteredFcmToken } from './model/useFcmLifecycle.client';
+export {
+  useFcmLifecycle,
+  removeRegisteredFcmToken,
+  readStoredFcmToken,
+} from './model/useFcmLifecycle.client';
 export { default as FcmBootstrap } from './ui/FcmBootstrap.client';

--- a/src/features/onboarding/index.ts
+++ b/src/features/onboarding/index.ts
@@ -8,6 +8,7 @@ export { sendEmailVerification } from './api/sendEmailVerification';
 export { verifyEmailVerification } from './api/verifyEmailVerification';
 export * from './model/useOnboardingProfileForm.client';
 export * from './model/useOnboardingFormState.client';
+export * from './model/useOnboardingMetadataQuery.client';
 export * from './model/useOnboardingReferenceData.client';
 export * from './model/useOnboardingOauthInfo.client';
 export * from './model/useOnboardingNicknameCheck.client';

--- a/src/features/onboarding/model/useOnboardingMetadataQuery.client.ts
+++ b/src/features/onboarding/model/useOnboardingMetadataQuery.client.ts
@@ -1,0 +1,25 @@
+'use client';
+
+import { useQuery } from '@tanstack/react-query';
+
+import { getOnboardingMetadata } from '../api/getOnboardingMetadata';
+
+export const onboardingMetadataQueryKey = ['onboarding', 'metadata'] as const;
+
+type UseOnboardingMetadataQueryOptions = {
+  enabled?: boolean;
+};
+
+export function useOnboardingMetadataQuery(options: UseOnboardingMetadataQueryOptions = {}) {
+  const { enabled = true } = options;
+
+  return useQuery({
+    queryKey: onboardingMetadataQueryKey,
+    queryFn: getOnboardingMetadata,
+    enabled,
+    staleTime: 60 * 60 * 1000,
+    gcTime: 24 * 60 * 60 * 1000,
+    refetchOnWindowFocus: false,
+    refetchOnReconnect: false,
+  });
+}

--- a/src/features/onboarding/model/useOnboardingReferenceData.client.ts
+++ b/src/features/onboarding/model/useOnboardingReferenceData.client.ts
@@ -1,50 +1,37 @@
 'use client';
 
-import { useEffect, useState } from 'react';
+import { useEffect, useMemo, useState } from 'react';
 
-import type { CareerLevel, Job, Skill } from '@/entities/onboarding';
-import { getOnboardingMetadata } from '@/features/onboarding';
 import { useCommonApiErrorHandler } from '@/shared/api';
+import { useOnboardingMetadataQuery } from './useOnboardingMetadataQuery.client';
 
 export function useOnboardingReferenceData() {
   const handleCommonApiError = useCommonApiErrorHandler();
-  const [skills, setSkills] = useState<Skill[]>([]);
-  const [jobs, setJobs] = useState<Job[]>([]);
-  const [careerLevels, setCareerLevels] = useState<CareerLevel[]>([]);
-  const [metadataLoading, setMetadataLoading] = useState(true);
   const [metadataError, setMetadataError] = useState<string | null>(null);
+  const { data, error, isLoading } = useOnboardingMetadataQuery();
 
   useEffect(() => {
-    let mounted = true;
-    getOnboardingMetadata()
-      .then((data) => {
-        if (!mounted) return;
-        setSkills(data.skills);
-        setJobs(data.jobs);
-        setCareerLevels(data.career_levels);
-      })
-      .catch(async (error) => {
-        if (!mounted) return;
-        if (await handleCommonApiError(error)) return;
-        setMetadataError(
-          error instanceof Error ? error.message : '온보딩 메타데이터를 불러오지 못했습니다.',
-        );
-      })
-      .finally(() => {
-        if (!mounted) return;
-        setMetadataLoading(false);
-      });
+    if (!error) {
+      setMetadataError(null);
+      return;
+    }
+    (async () => {
+      if (await handleCommonApiError(error)) return;
+      setMetadataError(
+        error instanceof Error ? error.message : '온보딩 메타데이터를 불러오지 못했습니다.',
+      );
+    })();
+  }, [error, handleCommonApiError]);
 
-    return () => {
-      mounted = false;
-    };
-  }, [handleCommonApiError]);
+  const skills = useMemo(() => data?.skills ?? [], [data]);
+  const jobs = useMemo(() => data?.jobs ?? [], [data]);
+  const careerLevels = useMemo(() => data?.career_levels ?? [], [data]);
 
   return {
     skills,
     jobs,
     careerLevels,
-    metadataLoading,
+    metadataLoading: isLoading,
     metadataError,
   };
 }

--- a/src/features/report/model/useReportList.client.ts
+++ b/src/features/report/model/useReportList.client.ts
@@ -1,9 +1,15 @@
 'use client';
 
 import { useEffect, useMemo, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
 import { useAuthStatus } from '@/entities/auth';
-import { deleteReport, getReports, type ReportSummary } from '@/entities/reports';
+import {
+  deleteReport,
+  reportsQueryKey,
+  useReportsQuery,
+  type ReportSummary,
+} from '@/entities/reports';
 import { useCommonApiErrorHandler } from '@/shared/api';
 
 export function useReportList() {
@@ -15,43 +21,40 @@ export function useReportList() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [isDeletingId, setIsDeletingId] = useState<number | null>(null);
   const [openMenuId, setOpenMenuId] = useState<number | null>(null);
+  const queryClient = useQueryClient();
+  const { data, error, isLoading } = useReportsQuery({ enabled: authStatus === 'authed' });
 
   useEffect(() => {
     if (authStatus !== 'authed') {
-      setReports([]);
-      setIsLoadingReports(false);
       setHasLoadedReports(false);
+      setLoadError(null);
+      setReports([]);
+      return;
+    }
+    setReports(data?.reports ?? []);
+    setHasLoadedReports(true);
+  }, [authStatus, data]);
+
+  useEffect(() => {
+    if (!error) {
       setLoadError(null);
       return;
     }
-
-    let cancelled = false;
-    setIsLoadingReports(true);
-
     (async () => {
-      try {
-        const data = await getReports();
-        if (cancelled) return;
-        setReports(data.reports ?? []);
-        setHasLoadedReports(true);
-        setLoadError(null);
-      } catch (error) {
-        if (cancelled) return;
-        if (await handleCommonApiError(error)) {
-          setIsLoadingReports(false);
-          return;
-        }
-        setHasLoadedReports(true);
-        setLoadError(error instanceof Error ? error.message : '리포트를 불러오지 못했습니다.');
-      } finally {
-        if (!cancelled) setIsLoadingReports(false);
-      }
+      if (await handleCommonApiError(error)) return;
+      setLoadError(error instanceof Error ? error.message : '리포트를 불러오지 못했습니다.');
     })();
+  }, [error, handleCommonApiError]);
 
-    return () => {
-      cancelled = true;
-    };
-  }, [authStatus, handleCommonApiError]);
+  useEffect(() => {
+    setIsLoadingReports(authStatus === 'authed' ? isLoading : false);
+  }, [authStatus, isLoading]);
+
+  useEffect(() => {
+    if (!openMenuId) return;
+    if (reports.some((report) => report.reportId === openMenuId)) return;
+    setOpenMenuId(null);
+  }, [openMenuId, reports]);
 
   const handleDeleteReport = async (reportId: number) => {
     if (isDeletingId) return;
@@ -61,7 +64,16 @@ export function useReportList() {
     setIsDeletingId(reportId);
     try {
       await deleteReport(reportId);
-      setReports((prev) => prev.filter((report) => report.reportId !== reportId));
+      queryClient.setQueryData<{ reports: ReportSummary[] } | undefined>(
+        reportsQueryKey,
+        (prev) => {
+          if (!prev) return { reports: [] };
+          return {
+            ...prev,
+            reports: prev.reports.filter((report) => report.reportId !== reportId),
+          };
+        },
+      );
     } catch (error) {
       if (!(await handleCommonApiError(error))) {
         setLoadError(error instanceof Error ? error.message : '리포트 삭제에 실패했습니다.');

--- a/src/features/resume/model/useResumeList.client.ts
+++ b/src/features/resume/model/useResumeList.client.ts
@@ -1,6 +1,7 @@
 import { useEffect, useState } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
 
-import { deleteResume, getResumes, type Resume } from '@/entities/resumes';
+import { deleteResume, resumesQueryKey, useResumesQuery, type Resume } from '@/entities/resumes';
 import { useAuthStatus } from '@/entities/auth';
 import { useCommonApiErrorHandler } from '@/shared/api';
 
@@ -12,41 +13,38 @@ export function useResumeList() {
   const [loadError, setLoadError] = useState<string | null>(null);
   const [openMenuId, setOpenMenuId] = useState<number | null>(null);
   const [isDeletingId, setIsDeletingId] = useState<number | null>(null);
+  const queryClient = useQueryClient();
+  const { data, error, isLoading } = useResumesQuery({ enabled: authStatus === 'authed' });
 
   useEffect(() => {
     if (authStatus !== 'authed') {
+      setLoadError(null);
       setResumes([]);
-      setIsLoadingResumes(false);
+      return;
+    }
+    setResumes(data?.resumes ?? []);
+  }, [authStatus, data]);
+
+  useEffect(() => {
+    if (!error) {
       setLoadError(null);
       return;
     }
-
-    let cancelled = false;
-    setIsLoadingResumes(true);
-
     (async () => {
-      try {
-        const data = await getResumes();
-        if (cancelled) return;
-        setResumes(data.resumes ?? []);
-        setLoadError(null);
-      } catch (error) {
-        if (cancelled) return;
-        if (await handleCommonApiError(error)) {
-          setIsLoadingResumes(false);
-          return;
-        }
-        setLoadError(error instanceof Error ? error.message : '이력서를 불러오지 못했습니다.');
-      } finally {
-        if (cancelled) return;
-        setIsLoadingResumes(false);
-      }
+      if (await handleCommonApiError(error)) return;
+      setLoadError(error instanceof Error ? error.message : '이력서를 불러오지 못했습니다.');
     })();
+  }, [error, handleCommonApiError]);
 
-    return () => {
-      cancelled = true;
-    };
-  }, [authStatus, handleCommonApiError]);
+  useEffect(() => {
+    setIsLoadingResumes(authStatus === 'authed' ? isLoading : false);
+  }, [authStatus, isLoading]);
+
+  useEffect(() => {
+    if (!openMenuId) return;
+    if (resumes.some((item) => item.resumeId === openMenuId)) return;
+    setOpenMenuId(null);
+  }, [openMenuId, resumes]);
 
   const handleDeleteResume = async (resumeId: number) => {
     if (isDeletingId) return;
@@ -56,7 +54,10 @@ export function useResumeList() {
 
     try {
       await deleteResume(resumeId);
-      setResumes((prev) => prev.filter((item) => item.resumeId !== resumeId));
+      queryClient.setQueryData<{ resumes: Resume[] } | undefined>(resumesQueryKey, (prev) => {
+        if (!prev) return { resumes: [] };
+        return { ...prev, resumes: prev.resumes.filter((item) => item.resumeId !== resumeId) };
+      });
     } catch (error) {
       await handleCommonApiError(error);
     } finally {

--- a/src/features/resume/model/useResumeSubmit.client.ts
+++ b/src/features/resume/model/useResumeSubmit.client.ts
@@ -2,8 +2,9 @@
 
 import { useState } from 'react';
 import { useRouter } from 'next/navigation';
+import { useQueryClient } from '@tanstack/react-query';
 
-import { createResume, updateResume } from '@/entities/resumes';
+import { createResume, resumesQueryKey, updateResume } from '@/entities/resumes';
 import { useCommonApiErrorHandler } from '@/shared/api';
 import type { CareerItem, ProjectItem, SimpleItem } from './useResumeEditForm.client';
 
@@ -39,6 +40,7 @@ export function useResumeSubmit({
   onError,
 }: UseResumeSubmitParams) {
   const router = useRouter();
+  const queryClient = useQueryClient();
   const handleCommonApiError = useCommonApiErrorHandler({ redirectTo: '/resume' });
   const [submitError, setSubmitError] = useState<string | null>(null);
   const [isSubmitting, setIsSubmitting] = useState(false);
@@ -122,6 +124,7 @@ export function useResumeSubmit({
           };
           await createResume(createPayload);
         }
+        await queryClient.invalidateQueries({ queryKey: resumesQueryKey });
         router.replace('/resume');
       } catch (error) {
         if (await handleCommonApiError(error)) {

--- a/src/shared/api/apiFetch.ts
+++ b/src/shared/api/apiFetch.ts
@@ -1,6 +1,7 @@
 import { readAccessToken } from './accessToken';
 import { BusinessError, HttpError } from './errors';
 import type { ApiResponse } from './types';
+import { trackApiRequest } from '@/shared/metrics/apiMetricsTracker';
 
 const DEFAULT_SUCCESS_CODES = ['SUCCESS', 'OK', 'CREATED'];
 
@@ -18,6 +19,12 @@ function getRequestUrl(input: RequestInfo): string | null {
   if (typeof URL !== 'undefined' && input instanceof URL) return input.toString();
   if (typeof Request !== 'undefined' && input instanceof Request) return input.url;
   return null;
+}
+
+function getRequestMethod(input: RequestInfo, init?: RequestInit): string {
+  if (init?.method) return init.method;
+  if (typeof Request !== 'undefined' && input instanceof Request) return input.method;
+  return 'GET';
 }
 
 function refreshInitWithLatestToken(init?: ApiFetchOptions): ApiFetchOptions | undefined {
@@ -45,13 +52,45 @@ export async function apiFetch<T>(input: RequestInfo, init?: ApiFetchOptions): P
     retryOnUnauthorized = true,
     ...fetchInit
   } = init ?? {};
-  const res = await fetch(input, {
-    credentials: 'include',
-    ...fetchInit,
+  const requestUrl = getRequestUrl(input);
+  const requestMethod = getRequestMethod(input, fetchInit);
+  const startTime =
+    typeof window !== 'undefined' && typeof performance !== 'undefined'
+      ? performance.now()
+      : Date.now();
+
+  let res: Response;
+  try {
+    res = await fetch(input, {
+      credentials: 'include',
+      ...fetchInit,
+    });
+  } catch (error) {
+    const endTime =
+      typeof window !== 'undefined' && typeof performance !== 'undefined'
+        ? performance.now()
+        : Date.now();
+    trackApiRequest({
+      url: requestUrl,
+      method: requestMethod,
+      status: 0,
+      durationMs: endTime - startTime,
+    });
+    throw error;
+  }
+
+  const endTime =
+    typeof window !== 'undefined' && typeof performance !== 'undefined'
+      ? performance.now()
+      : Date.now();
+  trackApiRequest({
+    url: requestUrl,
+    method: requestMethod,
+    status: res.status,
+    durationMs: endTime - startTime,
   });
 
   if (res.status === 401 && retryOnUnauthorized) {
-    const requestUrl = getRequestUrl(input);
     const isTokenRefresh = requestUrl?.includes('/bff/auth/tokens') ?? false;
     if (!isTokenRefresh) {
       const refreshed = await tryRefreshAuthTokens();

--- a/src/shared/metrics/apiMetricsTracker.ts
+++ b/src/shared/metrics/apiMetricsTracker.ts
@@ -1,0 +1,181 @@
+type ApiMetricInput = {
+  url: string | null;
+  method: string;
+  status: number;
+  durationMs: number;
+};
+
+type EndpointMetric = {
+  calls: number;
+  totalDurationMs: number;
+  durationsMs: number[];
+  calledAt: number[];
+  duplicateCalls: number;
+  rehitWithinWindowCalls: number;
+  errorCalls: number;
+};
+
+const DUP_WINDOW_MS = 30_000;
+const REPORT_INTERVAL_MS = 10_000;
+const MAX_SAMPLES_PER_ENDPOINT = 200;
+const UUID_REGEX =
+  /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
+
+const metricsByEndpoint = new Map<string, EndpointMetric>();
+let reportTimeoutId: ReturnType<typeof setTimeout> | null = null;
+let debugApiRegistered = false;
+
+declare global {
+  interface Window {
+    __apiMetricsPrint?: () => void;
+    __apiMetricsReset?: () => void;
+  }
+}
+
+function isEnabled() {
+  return (
+    typeof window !== 'undefined' &&
+    process.env.NODE_ENV === 'development' &&
+    process.env.NEXT_PUBLIC_API_METRICS === '1'
+  );
+}
+
+function pushLimited(list: number[], value: number) {
+  list.push(value);
+  if (list.length > MAX_SAMPLES_PER_ENDPOINT) {
+    list.shift();
+  }
+}
+
+function percentile(values: number[], p: number) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.max(0, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[index] ?? 0;
+}
+
+function normalizeUrl(rawUrl: string | null) {
+  if (!rawUrl) return 'unknown';
+
+  try {
+    const parsed = new URL(rawUrl, window.location.origin);
+    const normalizedPath = parsed.pathname
+      .replace(/\/\d+(?=\/|$)/g, '/:id')
+      .replace(UUID_REGEX, ':uuid');
+
+    // Keep only pagination-like params to avoid key explosion.
+    const keepParams = ['cursor', 'page', 'size', 'limit'];
+    const keptQuery = keepParams
+      .map((key) => {
+        const value = parsed.searchParams.get(key);
+        return value ? `${key}=${value}` : null;
+      })
+      .filter(Boolean)
+      .join('&');
+
+    return keptQuery ? `${normalizedPath}?${keptQuery}` : normalizedPath;
+  } catch {
+    return rawUrl.replace(/\/\d+(?=\/|$)/g, '/:id').replace(UUID_REGEX, ':uuid');
+  }
+}
+
+function getRecord(endpointKey: string): EndpointMetric {
+  const existing = metricsByEndpoint.get(endpointKey);
+  if (existing) return existing;
+
+  const created: EndpointMetric = {
+    calls: 0,
+    totalDurationMs: 0,
+    durationsMs: [],
+    calledAt: [],
+    duplicateCalls: 0,
+    rehitWithinWindowCalls: 0,
+    errorCalls: 0,
+  };
+
+  metricsByEndpoint.set(endpointKey, created);
+  return created;
+}
+
+function scheduleReport() {
+  if (reportTimeoutId) return;
+  reportTimeoutId = setTimeout(() => {
+    reportTimeoutId = null;
+    printApiMetrics();
+  }, REPORT_INTERVAL_MS);
+}
+
+function ensureDebugApi() {
+  if (!isEnabled() || debugApiRegistered) return;
+  window.__apiMetricsPrint = printApiMetrics;
+  window.__apiMetricsReset = resetApiMetrics;
+  debugApiRegistered = true;
+  console.info('[API Metrics] enabled. Use window.__apiMetricsPrint() to print now.');
+}
+
+function formatRate(value: number) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+export function trackApiRequest({ url, method, status, durationMs }: ApiMetricInput) {
+  if (!isEnabled()) return;
+  ensureDebugApi();
+
+  const endpoint = normalizeUrl(url);
+  const endpointKey = `${method.toUpperCase()} ${endpoint}`;
+  const now = Date.now();
+  const record = getRecord(endpointKey);
+
+  const prevCalledAt = record.calledAt[record.calledAt.length - 1];
+  if (record.calls > 0) {
+    record.duplicateCalls += 1;
+  }
+  if (typeof prevCalledAt === 'number' && now - prevCalledAt < DUP_WINDOW_MS) {
+    record.rehitWithinWindowCalls += 1;
+  }
+
+  record.calls += 1;
+  record.totalDurationMs += durationMs;
+  if (status >= 400 || status === 0) {
+    record.errorCalls += 1;
+  }
+  pushLimited(record.durationsMs, durationMs);
+  pushLimited(record.calledAt, now);
+
+  scheduleReport();
+}
+
+export function printApiMetrics() {
+  if (!isEnabled()) return;
+
+  const rows = Array.from(metricsByEndpoint.entries())
+    .map(([endpoint, data]) => {
+      const avg = data.calls > 0 ? data.totalDurationMs / data.calls : 0;
+      const p95 = percentile(data.durationsMs, 95);
+      const duplicateRate = data.calls > 0 ? data.duplicateCalls / data.calls : 0;
+      const rehitBase = Math.max(1, data.calls - 1);
+      const rehitWithin30sRate = data.rehitWithinWindowCalls / rehitBase;
+      const errorRate = data.calls > 0 ? data.errorCalls / data.calls : 0;
+
+      return {
+        endpoint,
+        calls: data.calls,
+        duplicateRate: formatRate(duplicateRate),
+        rehitWithin30sRate: formatRate(rehitWithin30sRate),
+        avgMs: Number(avg.toFixed(1)),
+        p95Ms: Number(p95.toFixed(1)),
+        errorRate: formatRate(errorRate),
+      };
+    })
+    .sort((a, b) => b.calls - a.calls);
+
+  if (rows.length === 0) return;
+
+  console.groupCollapsed(`[API Metrics] ${new Date().toLocaleTimeString()} (${rows.length})`);
+  console.table(rows);
+  console.groupEnd();
+}
+
+export function resetApiMetrics() {
+  metricsByEndpoint.clear();
+}

--- a/src/shared/metrics/apiMetricsTracker.ts
+++ b/src/shared/metrics/apiMetricsTracker.ts
@@ -18,8 +18,7 @@ type EndpointMetric = {
 const DUP_WINDOW_MS = 30_000;
 const REPORT_INTERVAL_MS = 10_000;
 const MAX_SAMPLES_PER_ENDPOINT = 200;
-const UUID_REGEX =
-  /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
+const UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
 
 const metricsByEndpoint = new Map<string, EndpointMetric>();
 let reportTimeoutId: ReturnType<typeof setTimeout> | null = null;

--- a/src/shared/metrics/index.ts
+++ b/src/shared/metrics/index.ts
@@ -1,3 +1,4 @@
 export { initWebVitals } from './web-vitals';
 export { sendMetrics } from './collector';
 export type { MetricType, MetricData } from './types';
+export { printApiMetrics, resetApiMetrics, trackApiRequest } from './apiMetricsTracker';

--- a/src/shared/metrics/serverApiMetricsTracker.ts
+++ b/src/shared/metrics/serverApiMetricsTracker.ts
@@ -1,0 +1,137 @@
+type ServerApiMetricInput = {
+  path: string;
+  method: string;
+  status: number;
+  durationMs: number;
+};
+
+type EndpointMetric = {
+  calls: number;
+  totalDurationMs: number;
+  durationsMs: number[];
+  calledAt: number[];
+  duplicateCalls: number;
+  rehitWithinWindowCalls: number;
+  errorCalls: number;
+};
+
+const DUP_WINDOW_MS = 30_000;
+const REPORT_INTERVAL_MS = 10_000;
+const MAX_SAMPLES = 200;
+const UUID_REGEX = /[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}/gi;
+
+const metricsByEndpoint = new Map<string, EndpointMetric>();
+let reportTimeoutId: ReturnType<typeof setTimeout> | null = null;
+
+function isEnabled() {
+  return process.env.NODE_ENV === 'development' && process.env.API_METRICS_SERVER === '1';
+}
+
+function pushLimited(list: number[], value: number) {
+  list.push(value);
+  if (list.length > MAX_SAMPLES) list.shift();
+}
+
+function percentile(values: number[], p: number) {
+  if (values.length === 0) return 0;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.max(0, Math.ceil((p / 100) * sorted.length) - 1);
+  return sorted[index] ?? 0;
+}
+
+function normalizePath(path: string) {
+  const [pathname, query = ''] = path.split('?');
+  const normalizedPath = pathname.replace(/\/\d+(?=\/|$)/g, '/:id').replace(UUID_REGEX, ':uuid');
+
+  const search = new URLSearchParams(query);
+  const keep = ['cursor', 'page', 'size', 'limit', 'status'];
+  const keptQuery = keep
+    .map((key) => {
+      const value = search.get(key);
+      return value ? `${key}=${value}` : null;
+    })
+    .filter(Boolean)
+    .join('&');
+
+  return keptQuery ? `${normalizedPath}?${keptQuery}` : normalizedPath;
+}
+
+function getRecord(key: string): EndpointMetric {
+  const existing = metricsByEndpoint.get(key);
+  if (existing) return existing;
+  const created: EndpointMetric = {
+    calls: 0,
+    totalDurationMs: 0,
+    durationsMs: [],
+    calledAt: [],
+    duplicateCalls: 0,
+    rehitWithinWindowCalls: 0,
+    errorCalls: 0,
+  };
+  metricsByEndpoint.set(key, created);
+  return created;
+}
+
+function scheduleReport() {
+  if (reportTimeoutId) return;
+  reportTimeoutId = setTimeout(() => {
+    reportTimeoutId = null;
+    printServerApiMetrics();
+  }, REPORT_INTERVAL_MS);
+}
+
+function formatRate(value: number) {
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+export function trackServerApiRequest({ path, method, status, durationMs }: ServerApiMetricInput) {
+  if (!isEnabled()) return;
+
+  const key = `${method.toUpperCase()} ${normalizePath(path)}`;
+  const now = Date.now();
+  const record = getRecord(key);
+  const prevCalledAt = record.calledAt[record.calledAt.length - 1];
+
+  if (record.calls > 0) record.duplicateCalls += 1;
+  if (typeof prevCalledAt === 'number' && now - prevCalledAt < DUP_WINDOW_MS) {
+    record.rehitWithinWindowCalls += 1;
+  }
+
+  record.calls += 1;
+  record.totalDurationMs += durationMs;
+  if (status >= 400 || status === 0) record.errorCalls += 1;
+  pushLimited(record.durationsMs, durationMs);
+  pushLimited(record.calledAt, now);
+
+  scheduleReport();
+}
+
+export function printServerApiMetrics() {
+  if (!isEnabled()) return;
+
+  const rows = Array.from(metricsByEndpoint.entries())
+    .map(([endpoint, data]) => {
+      const avg = data.calls > 0 ? data.totalDurationMs / data.calls : 0;
+      const p95 = percentile(data.durationsMs, 95);
+      const duplicateRate = data.calls > 0 ? data.duplicateCalls / data.calls : 0;
+      const rehitBase = Math.max(1, data.calls - 1);
+      const rehitWithin30sRate = data.rehitWithinWindowCalls / rehitBase;
+      const errorRate = data.calls > 0 ? data.errorCalls / data.calls : 0;
+
+      return {
+        endpoint,
+        calls: data.calls,
+        duplicateRate: formatRate(duplicateRate),
+        rehitWithin30sRate: formatRate(rehitWithin30sRate),
+        avgMs: Number(avg.toFixed(1)),
+        p95Ms: Number(p95.toFixed(1)),
+        errorRate: formatRate(errorRate),
+      };
+    })
+    .sort((a, b) => b.calls - a.calls);
+
+  if (rows.length === 0) return;
+
+  console.log(`[SERVER API Metrics] ${new Date().toISOString()} endpoints=${rows.length}`);
+  console.table(rows);
+}

--- a/src/widgets/notification/ui/NotificationPage.tsx
+++ b/src/widgets/notification/ui/NotificationPage.tsx
@@ -1,7 +1,7 @@
 'use client';
 
 import Image from 'next/image';
-import { useMemo } from 'react';
+import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { useAuthStatus } from '@/entities/auth';
@@ -13,9 +13,11 @@ import {
 } from '@/entities/notification';
 import { Footer } from '@/widgets/footer';
 import { Header } from '@/widgets/header';
+import { readStoredFcmToken } from '@/features/notification-fcm';
 import notificationChatRequest from '@/shared/icons/notification_chat_request.png';
 import notificationMessage from '@/shared/icons/notification_message.png';
 import notificationResumeAnalysis from '@/shared/icons/notification_resume_analysis.png';
+import { useToast } from '@/shared/ui/toast';
 
 function formatNotificationDate(value: string) {
   const date = new Date(value);
@@ -51,11 +53,13 @@ function sanitizeNotificationContent(content: string) {
 
 export default function NotificationPage() {
   const router = useRouter();
+  const { pushToast } = useToast();
   const { status: authStatus } = useAuthStatus();
   const isAuthed = authStatus === 'authed';
   const notificationsQuery = useNotificationsQuery(isAuthed);
   const readAllMutation = useReadAllNotificationsMutation();
   const readOneMutation = useReadNotificationMutation();
+  const [deviceToken, setDeviceToken] = useState<string | null>(null);
 
   const notifications = useMemo<NotificationItem[]>(() => {
     if (!notificationsQuery.data) return [];
@@ -63,6 +67,22 @@ export default function NotificationPage() {
   }, [notificationsQuery.data]);
 
   const unreadCount = notificationsQuery.data?.pages[0]?.unread_count ?? 0;
+
+  const handleShowToken = () => {
+    const token = readStoredFcmToken();
+    setDeviceToken(token);
+    if (!token) {
+      pushToast('저장된 디바이스 토큰이 없습니다.');
+      return;
+    }
+    pushToast('디바이스 토큰을 불러왔습니다.', { variant: 'success' });
+  };
+
+  const handleCopyToken = async () => {
+    if (!deviceToken) return;
+    await navigator.clipboard.writeText(deviceToken).catch(() => null);
+    pushToast('디바이스 토큰을 복사했습니다.', { variant: 'success' });
+  };
 
   return (
     <div className="flex min-h-[100dvh] flex-col bg-[#f7f7f7] text-black">
@@ -106,6 +126,33 @@ export default function NotificationPage() {
             </button>
           ) : null}
         </div>
+        {isAuthed ? (
+          <div className="mt-2 rounded-xl border border-[#d7e3f8] bg-[#f3f7ff] p-2">
+            <div className="flex items-center gap-2">
+              <button
+                type="button"
+                onClick={handleShowToken}
+                className="rounded-lg bg-[#35558b] px-3 py-1.5 text-xs font-semibold text-white"
+              >
+                토큰 보기
+              </button>
+              {deviceToken ? (
+                <button
+                  type="button"
+                  onClick={handleCopyToken}
+                  className="rounded-lg border border-[#35558b] px-3 py-1.5 text-xs font-semibold text-[#35558b]"
+                >
+                  토큰 복사
+                </button>
+              ) : null}
+            </div>
+            {deviceToken ? (
+              <p className="mt-2 break-all rounded-md bg-white p-2 text-[11px] text-[#3b4f6f]">
+                {deviceToken}
+              </p>
+            ) : null}
+          </div>
+        ) : null}
 
         {!isAuthed ? (
           <p className="mt-6 rounded-2xl bg-white py-10 text-center text-sm text-text-caption shadow-sm">


### PR DESCRIPTION
## 📌 변경 사항
- 개인정보 수정 후 `user/me` 캐시 즉시 동기화(`setQueryData` + `invalidateQueries`)로 새로고침 의존 제거
- 클라이언트/서버 API 계측 도구 추가(호출 수, 중복률, 30초 재호출률, avg/p95, errorRate)
- 전문가 추천 BFF에 사용자별 단기 캐시(30초) + 장애 시 stale fallback(최대 5분) 적용
- `resumes`를 TanStack Query 공통 캐시로 전환(`useResumeList`/`useExpertResumes` 공유)
- `reports` 목록도 TanStack Query 공통 캐시로 전환
- 온보딩 메타데이터(`jobs/career-levels/skills`)를 단일 쿼리로 통합 캐시
- `users/me` 쿼리 재요청 정책 최적화(staleTime 확장, focus/reconnect refetch 비활성화)
- 오늘 작업 내용을 개발일지 문서화(`docs/개발일지/2026-02-24.md`)

## 🔍 상세 내용
- 계측은 개발 환경에서만 활성화되며, 클라이언트(`NEXT_PUBLIC_API_METRICS=1`)와 서버(`API_METRICS_SERVER=1`)를 분리해 확인 가능
- 측정 값은 endpoint 정규화 후 집계하여 동적 path/query로 인한 key 폭발을 방지
- `resumes/reports`는 공통 query key(`['resumes']`, `['reports']`)로 상태를 단일화해 화면 간 중복 fetch를 줄임
- 삭제 액션은 `setQueryData`로 즉시 UI 반영, 생성/수정은 `invalidateQueries`로 최신 서버 상태 재검증
- 온보딩 메타데이터는 변동이 낮은 참조 데이터로 판단해 긴 staleTime(1h) + 긴 gcTime(24h) 적용
- `users/me`는 여러 화면에서 참조되는 전역 상태라 재요청 정책 조정으로 중복 호출을 완화
- 추천 API는 SSR 경로 특성상 TanStack Query보다 BFF 캐시가 효과적이라 서버 캐시로 우선 대응
- 현재 가장 큰 잔여 리스크는 `experts/recommendations` 업스트림 오류율(캐시와 별개로 백엔드 안정화 필요)

## ✅ 체크리스트
- [X] 기능이 정상적으로 동작하는지 확인했습니다.
- [X] 기존 기능에 영향을 주지 않는지 확인했습니다.


