### PR TITLE
[ISSUE - #243] 비동기 처리 구조 개선 및 SSE 도입

### DIFF
--- a/public/firebase-messaging-sw.js
+++ b/public/firebase-messaging-sw.js
@@ -5,7 +5,9 @@ const STATIC_CACHE = 'refit-static-v1';
 const PAGE_CACHE = 'refit-pages-v1';
 const PUBLIC_API_CACHE = 'refit-public-api-v1';
 const OFFLINE_URL = '/offline.html';
-const SW_VERSION = '2026-02-24';
+const SW_VERSION = '2026-02-27';
+const NOTIFICATION_DEDUP_WINDOW_MS = 8000;
+const recentlyShownNotifications = new Map();
 
 const STATIC_PATH_PREFIXES = ['/_next/static/', '/icons/', '/assets/', '/lottie/'];
 const PERSONALIZED_API_PREFIXES = [
@@ -150,15 +152,69 @@ firebase.initializeApp({
 
 const messaging = firebase.messaging();
 
-messaging.onBackgroundMessage((payload) => {
-  const title = payload.notification?.title || '알림';
-  const options = {
-    body: payload.notification?.body || '',
-    icon: '/icons/char_icon.png',
-    data: payload.data || {},
-  };
+function sanitizeNotificationText(value) {
+  const text = String(value || '');
+  return text
+    .replace(/\s*\(task_id:[^)]+\)\s*$/i, '')
+    .replace(/\(?["']?task[_-]?id["']?\s*[:=]\s*["']?[^,"'\s)]+["']?\)?/gi, '')
+    .replace(/\(?["']?taskid["']?\s*[:=]\s*["']?[^,"'\s)]+["']?\)?/gi, '')
+    .replace(/\{\s*,/g, '{')
+    .replace(/,\s*,/g, ',')
+    .replace(/\(\s*\)/g, '')
+    .replace(/\s{2,}/g, ' ')
+    .replace(/\s+,/g, ',')
+    .replace(/,\s*$/g, '')
+    .trim();
+}
 
-  self.registration.showNotification(title, options);
+function shouldSuppressDuplicate(signature) {
+  const now = Date.now();
+  const lastShownAt = recentlyShownNotifications.get(signature) || 0;
+  recentlyShownNotifications.forEach((shownAt, key) => {
+    if (now - shownAt > NOTIFICATION_DEDUP_WINDOW_MS) {
+      recentlyShownNotifications.delete(key);
+    }
+  });
+  if (now - lastShownAt < NOTIFICATION_DEDUP_WINDOW_MS) {
+    return true;
+  }
+  recentlyShownNotifications.set(signature, now);
+  return false;
+}
+
+messaging.onBackgroundMessage((payload) => {
+  void (async () => {
+    const windowClients = await clients.matchAll({ type: 'window', includeUncontrolled: true });
+    const hasActiveClient = windowClients.some((client) => {
+      const visibilityState = client.visibilityState;
+      return client.focused || visibilityState === 'visible' || visibilityState === 'prerender';
+    });
+    if (hasActiveClient || windowClients.length > 0) {
+      return;
+    }
+
+    const title = sanitizeNotificationText(payload.notification?.title || '알림');
+    const body = sanitizeNotificationText(payload.notification?.body || '');
+    const notificationId =
+      payload.data?.notification_id ||
+      payload.data?.notificationId ||
+      payload.data?.messageId ||
+      '';
+    const signature = [title, body, notificationId].filter(Boolean).join('|');
+    if (signature && shouldSuppressDuplicate(signature)) {
+      return;
+    }
+
+    const options = {
+      body,
+      icon: '/icons/char_icon.png',
+      data: payload.data || {},
+      tag: notificationId || signature || undefined,
+      renotify: false,
+    };
+
+    self.registration.showNotification(title, options);
+  })();
 });
 
 self.addEventListener('notificationclick', (event) => {

--- a/src/app/bff/_lib/fetchUpstream.ts
+++ b/src/app/bff/_lib/fetchUpstream.ts
@@ -22,7 +22,12 @@ function resolveTimeoutProfile(
 ): TimeoutProfile {
   if (override) return override;
   if (upstreamPath.startsWith('/api/v1/experts/recommendations')) return 'optional';
-  if (upstreamPath.startsWith('/api/v1/resumes/tasks')) return 'critical';
+  if (
+    upstreamPath.startsWith('/api/v1/resumes/tasks') ||
+    upstreamPath.startsWith('/api/v2/resumes/tasks')
+  ) {
+    return 'critical';
+  }
   if (upstreamPath.startsWith('/api/v2/reports')) return method === 'GET' ? 'critical' : 'default';
   return 'default';
 }

--- a/src/app/bff/chat/[chatId]/feedback/route.ts
+++ b/src/app/bff/chat/[chatId]/feedback/route.ts
@@ -1,9 +1,12 @@
+import { after } from 'next/server';
 import { NextResponse } from 'next/server';
 import { cookies } from 'next/headers';
 
-import { createChatFeedback } from '@/features/chat.server';
+import { createChatFeedback, requestReportCreate } from '@/features/chat.server';
 import { BusinessError, type ApiResponse } from '@/shared/api';
 import type { ChatFeedbackRequest } from '@/entities/chat';
+
+const CHAT_FEEDBACK_BFF_TIMEOUT_MS = 30000;
 
 type Params = {
   chatId: string;
@@ -51,6 +54,17 @@ export async function POST(req: Request, context: { params: Params }) {
     const accessToken = getAccessToken(req, cookieToken);
 
     const data = await createChatFeedback({ chatId, payload, accessToken, allowRefresh: false });
+    after(async () => {
+      try {
+        await requestReportCreate({ chatId, accessToken, allowRefresh: false });
+      } catch (backgroundError) {
+        console.error('[Report Create Async Error]', {
+          chatId,
+          error:
+            backgroundError instanceof Error ? backgroundError.message : 'unknown_background_error',
+        });
+      }
+    });
 
     const response: ApiResponse<typeof data> = {
       code: 'CREATED',
@@ -67,7 +81,7 @@ export async function POST(req: Request, context: { params: Params }) {
         bffPath: '/bff/chat/[chatId]/feedback',
         upstreamPath: '/api/v2/chats/{chatId}/feedback',
         method: 'POST',
-        timeoutMs: 30000,
+        timeoutMs: CHAT_FEEDBACK_BFF_TIMEOUT_MS,
         requestId,
       });
 
@@ -77,7 +91,7 @@ export async function POST(req: Request, context: { params: Params }) {
         data: null,
       };
       return NextResponse.json(
-        { ...response, degraded: true, requestId, timeoutMs: 30000 },
+        { ...response, degraded: true, requestId, timeoutMs: CHAT_FEEDBACK_BFF_TIMEOUT_MS },
         { status: 504 },
       );
     }

--- a/src/app/bff/resumes/tasks/[taskId]/route.ts
+++ b/src/app/bff/resumes/tasks/[taskId]/route.ts
@@ -1,0 +1,90 @@
+import { NextResponse } from 'next/server';
+import { cookies } from 'next/headers';
+
+import { BusinessError, type ApiResponse, buildApiUrl } from '@/shared/api';
+import { fetchBffUpstream } from '@/app/bff/_lib/fetchUpstream';
+
+type Params = {
+  params: Promise<{
+    taskId: string;
+  }>;
+};
+
+function getAccessToken(req: Request, cookieToken?: string) {
+  const authHeader = req.headers.get('authorization');
+  const rawToken = authHeader?.startsWith('Bearer ')
+    ? authHeader.slice(7)
+    : (authHeader ?? undefined);
+  return rawToken?.trim() || cookieToken?.trim() || undefined;
+}
+
+export async function GET(req: Request, { params }: Params) {
+  try {
+    const { taskId } = await params;
+    if (!taskId) {
+      const response: ApiResponse<null> = {
+        code: 'INVALID_TASK_ID',
+        message: 'INVALID_TASK_ID',
+        data: null,
+      };
+      return NextResponse.json(response, { status: 400 });
+    }
+
+    const cookieStore = await cookies();
+    const cookieToken = cookieStore.get('access_token')?.value;
+    const accessToken = getAccessToken(req, cookieToken);
+    if (!accessToken) {
+      const response: ApiResponse<null> = {
+        code: 'AUTH_UNAUTHORIZED',
+        message: 'unauthorized',
+        data: null,
+      };
+      return NextResponse.json(response, { status: 401 });
+    }
+
+    const encodedTaskId = encodeURIComponent(taskId);
+    const res = await fetchBffUpstream(buildApiUrl(`/api/v2/resumes/tasks/${encodedTaskId}`), {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+
+    if (!res.ok) {
+      const body = await res.json().catch(() => null);
+      if (body && typeof body.code === 'string') {
+        const response: ApiResponse<unknown> = {
+          code: body.code,
+          message: body.message ?? 'error',
+          data: body.data ?? null,
+        };
+        return NextResponse.json(response, { status: res.status });
+      }
+      const response: ApiResponse<null> = {
+        code: 'RESUME_PARSE_TASK_FAILED',
+        message: 'RESUME_PARSE_TASK_FAILED',
+        data: null,
+      };
+      return NextResponse.json(response, { status: res.status });
+    }
+
+    const body = await res.json();
+    return NextResponse.json(body, { status: res.status });
+  } catch (error) {
+    if (error instanceof BusinessError) {
+      const response: ApiResponse<unknown> = {
+        code: error.code,
+        message: error.message,
+        data: error.data ?? null,
+      };
+      return NextResponse.json(response);
+    }
+
+    console.error('[Resume Parse Task Error]', error);
+    const response: ApiResponse<null> = {
+      code: 'RESUME_PARSE_TASK_FAILED',
+      message: 'RESUME_PARSE_TASK_FAILED',
+      data: null,
+    };
+    return NextResponse.json(response, { status: 500 });
+  }
+}

--- a/src/app/bff/resumes/tasks/route.ts
+++ b/src/app/bff/resumes/tasks/route.ts
@@ -24,16 +24,50 @@ export async function POST(req: Request) {
       return NextResponse.json(response, { status: 401 });
     }
 
-    const payload = await req.json();
-    const res = await fetchBffUpstream(buildApiUrl('/api/v1/resumes/tasks'), {
-      timeoutMs: 30000,
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${accessToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify(payload),
-    });
+    const payload = (await req.json()) as { file_url?: unknown; fileUrl?: unknown };
+    const rawFileUrl = payload.file_url ?? payload.fileUrl;
+    const fileUrl = typeof rawFileUrl === 'string' ? rawFileUrl.trim() : '';
+    if (!fileUrl) {
+      const response: ApiResponse<null> = {
+        code: 'INVALID_PAYLOAD',
+        message: 'file_url is required',
+        data: null,
+      };
+      return NextResponse.json(response, { status: 400 });
+    }
+
+    const requestHeaders = {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    };
+    const candidates: Array<{ body: Record<string, string> }> = [
+      { body: { file_url: fileUrl, mode: 'async' } },
+      { body: { file_url: fileUrl } },
+      { body: { fileUrl, mode: 'async' } },
+      { body: { fileUrl } },
+    ];
+
+    let res: Response | null = null;
+    for (const candidate of candidates) {
+      res = await fetchBffUpstream(buildApiUrl('/api/v2/resumes/tasks'), {
+        timeoutMs: 30000,
+        method: 'POST',
+        headers: requestHeaders,
+        body: JSON.stringify(candidate.body),
+      });
+
+      if (res.ok) break;
+      if (res.status !== 400 && res.status !== 404) break;
+    }
+
+    if (!res) {
+      const response: ApiResponse<null> = {
+        code: 'RESUME_PARSE_FAILED',
+        message: 'RESUME_PARSE_FAILED',
+        data: null,
+      };
+      return NextResponse.json(response, { status: 500 });
+    }
 
     if (!res.ok) {
       const body = await res.json().catch(() => null);

--- a/src/app/bff/resumes/tasks/stream/route.ts
+++ b/src/app/bff/resumes/tasks/stream/route.ts
@@ -1,0 +1,179 @@
+import { cookies } from 'next/headers';
+
+import { buildApiUrl } from '@/shared/api';
+import { fetchBffUpstream } from '@/app/bff/_lib/fetchUpstream';
+
+const POLL_INTERVAL_MS = 2000;
+const KEEPALIVE_MS = 15000;
+
+type StreamStatusPayload = {
+  taskId: string;
+  status: 'PROCESSING' | 'COMPLETED' | 'FAILED';
+  result?: unknown;
+  reason?: string;
+};
+
+function getAccessToken(req: Request, cookieToken?: string) {
+  const authHeader = req.headers.get('authorization');
+  const rawToken = authHeader?.startsWith('Bearer ')
+    ? authHeader.slice(7)
+    : (authHeader ?? undefined);
+  return rawToken?.trim() || cookieToken?.trim() || undefined;
+}
+
+function parseTaskIds(req: Request): string[] {
+  const url = new URL(req.url);
+  const repeated = url.searchParams.getAll('taskId');
+  const csv = (url.searchParams.get('taskIds') ?? '')
+    .split(',')
+    .map((item) => item.trim())
+    .filter(Boolean);
+  return Array.from(new Set([...repeated, ...csv].map((item) => item.trim()).filter(Boolean)));
+}
+
+export async function GET(req: Request) {
+  const taskIds = parseTaskIds(req);
+  if (taskIds.length === 0) {
+    return Response.json(
+      {
+        code: 'INVALID_TASK_IDS',
+        message: 'taskId query is required',
+        data: null,
+      },
+      { status: 400 },
+    );
+  }
+
+  const cookieStore = await cookies();
+  const cookieToken = cookieStore.get('access_token')?.value;
+  const accessToken = getAccessToken(req, cookieToken);
+  if (!accessToken) {
+    return Response.json(
+      {
+        code: 'AUTH_UNAUTHORIZED',
+        message: 'unauthorized',
+        data: null,
+      },
+      { status: 401 },
+    );
+  }
+
+  const encoder = new TextEncoder();
+
+  const stream = new ReadableStream({
+    start(controller) {
+      const active = new Set(taskIds);
+      let closed = false;
+      let polling = false;
+      let pollTimer: ReturnType<typeof setInterval> | null = null;
+      let keepAliveTimer: ReturnType<typeof setInterval> | null = null;
+
+      const writeEvent = (event: string, payload: unknown) => {
+        if (closed) return;
+        const chunk = `event: ${event}\ndata: ${JSON.stringify(payload)}\n\n`;
+        controller.enqueue(encoder.encode(chunk));
+      };
+
+      const close = () => {
+        if (closed) return;
+        closed = true;
+        if (pollTimer) clearInterval(pollTimer);
+        if (keepAliveTimer) clearInterval(keepAliveTimer);
+        try {
+          controller.close();
+        } catch {
+          // stream already closed
+        }
+      };
+
+      const poll = async () => {
+        if (closed || polling) return;
+        polling = true;
+        try {
+          for (const taskId of Array.from(active)) {
+            const upstream = await fetchBffUpstream(
+              buildApiUrl(`/api/v2/resumes/tasks/${encodeURIComponent(taskId)}`),
+              {
+                headers: { Authorization: `Bearer ${accessToken}` },
+                timeoutProfile: 'critical',
+                bffPath: '/bff/resumes/tasks/stream',
+              },
+            );
+
+            if (!upstream.ok) {
+              const body = await upstream.json().catch(() => null);
+              const code = body && typeof body.code === 'string' ? body.code : null;
+
+              if (code === 'TASK_NOT_FOUND' || upstream.status === 404) {
+                const payload: StreamStatusPayload = {
+                  taskId,
+                  status: 'FAILED',
+                  reason: 'TASK_NOT_FOUND',
+                };
+                writeEvent('status', payload);
+                active.delete(taskId);
+                continue;
+              }
+
+              const payload: StreamStatusPayload = {
+                taskId,
+                status: 'PROCESSING',
+                reason: code ?? `HTTP_${upstream.status}`,
+              };
+              writeEvent('status', payload);
+              continue;
+            }
+
+            const body = await upstream.json().catch(() => null);
+            const data =
+              body && typeof body === 'object' && 'data' in body
+                ? (body as { data?: { status?: string; result?: unknown } }).data
+                : null;
+            const status =
+              data?.status === 'COMPLETED' || data?.status === 'FAILED' ? data.status : 'PROCESSING';
+
+            const payload: StreamStatusPayload = {
+              taskId,
+              status,
+              result: status === 'COMPLETED' ? data?.result : undefined,
+            };
+            writeEvent('status', payload);
+
+            if (status === 'COMPLETED' || status === 'FAILED') {
+              active.delete(taskId);
+            }
+          }
+
+          if (active.size === 0) {
+            writeEvent('done', { done: true });
+            close();
+          }
+        } finally {
+          polling = false;
+        }
+      };
+
+      writeEvent('ready', { taskIds });
+      void poll();
+
+      pollTimer = setInterval(() => {
+        void poll();
+      }, POLL_INTERVAL_MS);
+
+      keepAliveTimer = setInterval(() => {
+        writeEvent('ping', { ts: Date.now() });
+      }, KEEPALIVE_MS);
+
+      req.signal.addEventListener('abort', close);
+    },
+  });
+
+  return new Response(stream, {
+    headers: {
+      'Content-Type': 'text/event-stream; charset=utf-8',
+      'Cache-Control': 'no-cache, no-transform',
+      Connection: 'keep-alive',
+      'X-Accel-Buffering': 'no',
+    },
+  });
+}

--- a/src/entities/chat/index.ts
+++ b/src/entities/chat/index.ts
@@ -2,3 +2,9 @@ export * from './types';
 export { normalizeChatList, normalizeChatListData } from './lib/chatList';
 export { normalizeChatDetail } from './lib/chatDetail';
 export { normalizeRequestTypeFromUnknown } from './lib/requestType';
+export {
+  CHAT_REALTIME_REFRESH_EVENT,
+  CHAT_LIST_REFRESH_EVENT,
+  parseChatRealtimePayload,
+} from './lib/realtimeEvent';
+export type { ChatRealtimeRefreshPayload } from './lib/realtimeEvent';

--- a/src/entities/chat/lib/realtimeEvent.ts
+++ b/src/entities/chat/lib/realtimeEvent.ts
@@ -1,0 +1,36 @@
+export const CHAT_REALTIME_REFRESH_EVENT = 'chat-realtime-refresh';
+export const CHAT_LIST_REFRESH_EVENT = 'chat-list-refresh';
+
+export type ChatRealtimeRefreshPayload = {
+  chatId: number;
+  messageId?: number;
+  eventType?: string;
+};
+
+type ChatEventLike = {
+  chat_id?: unknown;
+  chatId?: unknown;
+  message_id?: unknown;
+  messageId?: unknown;
+  type?: unknown;
+};
+
+function toNumber(value: unknown): number | null {
+  if (typeof value === 'number' && Number.isFinite(value)) return value;
+  if (typeof value === 'string' && value.trim()) {
+    const parsed = Number(value);
+    if (Number.isFinite(parsed)) return parsed;
+  }
+  return null;
+}
+
+export function parseChatRealtimePayload(raw: unknown): ChatRealtimeRefreshPayload | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const event = raw as ChatEventLike;
+  const chatId = toNumber(event.chat_id ?? event.chatId);
+  if (chatId === null) return null;
+
+  const messageId = toNumber(event.message_id ?? event.messageId) ?? undefined;
+  const eventType = typeof event.type === 'string' ? event.type : undefined;
+  return { chatId, messageId, eventType };
+}

--- a/src/entities/chat/types.ts
+++ b/src/entities/chat/types.ts
@@ -12,8 +12,10 @@ export interface ChatFeedbackRequest {
 }
 
 export interface ChatFeedbackCreatedData {
-  chat_feedback_id: number;
-  chat_id: number;
+  reportId?: number;
+  report_id?: number;
+  chat_feedback_id?: number;
+  chat_id?: number;
 }
 
 export interface SendChatMessageRequest {

--- a/src/entities/resumes/api/getResumes.ts
+++ b/src/entities/resumes/api/getResumes.ts
@@ -3,6 +3,7 @@ import { apiFetch } from '@/shared/api';
 export type Resume = {
   resumeId: number;
   title: string;
+  status?: string;
   isFresher: boolean;
   educationLevel: string;
   fileUrl: string;
@@ -18,6 +19,7 @@ type ResumeApiResponse = {
   resumeId?: number;
   resume_id?: number;
   title?: string;
+  status?: string;
   isFresher?: boolean;
   is_fresher?: boolean;
   educationLevel?: string;
@@ -41,6 +43,7 @@ const normalizeResume = (resume: ResumeApiResponse, index: number): Resume => {
   return {
     resumeId,
     title: resume.title ?? '',
+    status: resume.status ?? '',
     isFresher: resume.isFresher ?? resume.is_fresher ?? false,
     educationLevel: resume.educationLevel ?? resume.education_level ?? '',
     fileUrl: resume.fileUrl ?? resume.file_url ?? '',

--- a/src/entities/resumes/api/parseResumeSync.ts
+++ b/src/entities/resumes/api/parseResumeSync.ts
@@ -1,8 +1,7 @@
 import { apiFetch } from '@/shared/api';
 
-export type ResumeParseSyncRequest = {
+export type ResumeParseTaskRequest = {
   file_url: string;
-  mode: 'sync';
 };
 
 export type ResumeParseProject = {
@@ -31,27 +30,59 @@ export type ResumeParseContentJson = {
   activities?: string[];
 };
 
-export type ResumeParseSyncResult = {
+export type ResumeParseTaskResult = {
+  isFresher?: boolean;
+  educationLevel?: string;
+  contentJson?: ResumeParseContentJson;
+  rawTextExcerpt?: string;
   is_fresher?: boolean;
   education_level?: string;
   content_json?: ResumeParseContentJson;
   raw_text_excerpt?: string;
 };
 
-export type ResumeParseSyncData = {
-  task_id: string;
+type ResumeParseTaskApiData = {
+  taskId?: string;
+  task_id?: string;
   status: string;
-  result: ResumeParseSyncResult | null;
+  result: ResumeParseTaskResult | null;
 };
 
-export async function parseResumeSync(
-  payload: ResumeParseSyncRequest,
-): Promise<ResumeParseSyncData> {
-  return apiFetch<ResumeParseSyncData>('/bff/resumes/tasks', {
+export type ResumeParseTaskData = {
+  taskId: string;
+  status: string;
+  result: ResumeParseTaskResult | null;
+};
+
+const normalizeResult = (result: ResumeParseTaskResult): ResumeParseTaskResult => ({
+  is_fresher: result.is_fresher ?? result.isFresher,
+  education_level: result.education_level ?? result.educationLevel,
+  content_json: result.content_json ?? result.contentJson,
+  raw_text_excerpt: result.raw_text_excerpt ?? result.rawTextExcerpt,
+});
+
+const normalizeTaskData = (data: ResumeParseTaskApiData): ResumeParseTaskData => ({
+  taskId: data.taskId ?? data.task_id ?? '',
+  status: data.status ?? 'PROCESSING',
+  result: data.result ? normalizeResult(data.result) : null,
+});
+
+export async function parseResumeTask(
+  payload: ResumeParseTaskRequest,
+): Promise<ResumeParseTaskData> {
+  const data = await apiFetch<ResumeParseTaskApiData>('/bff/resumes/tasks', {
     method: 'POST',
     headers: {
       'Content-Type': 'application/json',
     },
     body: JSON.stringify(payload),
   });
+
+  return normalizeTaskData(data);
+}
+
+export async function getResumeParseTask(taskId: string): Promise<ResumeParseTaskData> {
+  const encodedTaskId = encodeURIComponent(taskId);
+  const data = await apiFetch<ResumeParseTaskApiData>(`/bff/resumes/tasks/${encodedTaskId}`);
+  return normalizeTaskData(data);
 }

--- a/src/entities/resumes/index.ts
+++ b/src/entities/resumes/index.ts
@@ -4,7 +4,7 @@ export { getResumeDetail } from './api/getResumeDetail';
 export { deleteResume } from './api/deleteResume';
 export { updateResumeTitle } from './api/updateResumeTitle';
 export { updateResume } from './api/updateResume';
-export { parseResumeSync } from './api/parseResumeSync';
+export { parseResumeTask, getResumeParseTask } from './api/parseResumeSync';
 export { useResumesQuery, resumesQueryKey } from './model/useResumesQuery.client';
 export type { Resume, ResumesResponse } from './api/getResumes';
 export type { CreateResumePayload, CreateResumeResponse } from './api/createResume';
@@ -14,12 +14,17 @@ export type { UpdateResumePayload } from './api/updateResume';
 export type {
   ResumeParseContentJson,
   ResumeParseProject,
-  ResumeParseSyncData,
-  ResumeParseSyncRequest,
-  ResumeParseSyncResult,
+  ResumeParseTaskData,
+  ResumeParseTaskRequest,
+  ResumeParseTaskResult,
 } from './api/parseResumeSync';
 export {
   normalizeResumeContent,
   normalizeResumeDetail,
   toStringArray,
 } from './lib/normalizeResumeDetail';
+export {
+  RESUME_TASK_REFRESH_EVENT,
+  parseResumeTaskRealtimePayload,
+} from './lib/realtimeEvent';
+export type { ResumeTaskRefreshPayload } from './lib/realtimeEvent';

--- a/src/entities/resumes/lib/realtimeEvent.ts
+++ b/src/entities/resumes/lib/realtimeEvent.ts
@@ -1,0 +1,44 @@
+export const RESUME_TASK_REFRESH_EVENT = 'resume-task-refresh';
+
+export type ResumeTaskRefreshPayload = {
+  taskId: string;
+  status: 'PROCESSING' | 'COMPLETED' | 'FAILED';
+  result?: unknown;
+};
+
+type ResumeEventLike = {
+  type?: unknown;
+  taskId?: unknown;
+  task_id?: unknown;
+  status?: unknown;
+  result?: unknown;
+  data?: unknown;
+};
+
+function normalizeStatus(value: unknown): ResumeTaskRefreshPayload['status'] | null {
+  if (typeof value !== 'string') return null;
+  const normalized = value.toUpperCase();
+  if (normalized === 'PROCESSING' || normalized === 'COMPLETED' || normalized === 'FAILED') {
+    return normalized;
+  }
+  return null;
+}
+
+export function parseResumeTaskRealtimePayload(raw: unknown): ResumeTaskRefreshPayload | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const event = raw as ResumeEventLike;
+
+  const target =
+    event.data && typeof event.data === 'object' ? ({ ...event.data, type: event.type } as ResumeEventLike) : event;
+  const taskIdValue = target.taskId ?? target.task_id;
+  if (typeof taskIdValue !== 'string' || !taskIdValue.trim()) return null;
+
+  const status = normalizeStatus(target.status);
+  if (!status) return null;
+
+  return {
+    taskId: taskIdValue.trim(),
+    status,
+    result: target.result,
+  };
+}

--- a/src/features/chat.server.ts
+++ b/src/features/chat.server.ts
@@ -10,4 +10,5 @@ export {
   markChatRead,
   updateChatLastRead,
   createChatFeedback,
+  requestReportCreate,
 } from './chat/server';

--- a/src/features/chat/index.ts
+++ b/src/features/chat/index.ts
@@ -23,3 +23,4 @@ export * from './model/useChatRoomDetail.client';
 export * from './model/useChatSend.client';
 export * from './model/useChatFeedbackForm.client';
 export * from './lib/message';
+export * from './lib/reportCreate.client';

--- a/src/features/chat/lib/reportCreate.client.ts
+++ b/src/features/chat/lib/reportCreate.client.ts
@@ -1,0 +1,18 @@
+'use client';
+
+export const REPORT_CREATE_ACCEPTED_EVENT = 'report-create-accepted';
+export const REPORT_CREATE_ACCEPTED_STORAGE_KEY = 'reportCreateAccepted';
+
+export function markReportCreateAccepted() {
+  if (typeof window === 'undefined') return;
+  sessionStorage.setItem(REPORT_CREATE_ACCEPTED_STORAGE_KEY, 'true');
+  window.dispatchEvent(new Event(REPORT_CREATE_ACCEPTED_EVENT));
+}
+
+export function consumeReportCreateAccepted(): boolean {
+  if (typeof window === 'undefined') return false;
+  const flag = sessionStorage.getItem(REPORT_CREATE_ACCEPTED_STORAGE_KEY);
+  if (!flag) return false;
+  sessionStorage.removeItem(REPORT_CREATE_ACCEPTED_STORAGE_KEY);
+  return true;
+}

--- a/src/features/chat/model/useChatFeedbackForm.client.ts
+++ b/src/features/chat/model/useChatFeedbackForm.client.ts
@@ -3,9 +3,9 @@
 import { useMemo, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
-import { closeChat, createChatFeedback } from '@/features/chat';
+import { markReportCreateAccepted } from '@/features/chat';
 import type { ChatFeedbackRequest } from '@/entities/chat';
-import { BusinessError, useCommonApiErrorHandler } from '@/shared/api';
+import { readAccessToken } from '@/shared/api';
 
 export type FeedbackAnswerKind = 'multi' | 'radio' | 'text';
 
@@ -163,7 +163,6 @@ type Step2Evaluations = Record<string, { status: string; reason: string }>;
 
 export function useChatFeedbackForm(chatId: number) {
   const router = useRouter();
-  const handleCommonApiError = useCommonApiErrorHandler();
   const [answers, setAnswers] = useState<Record<number, string | string[]>>({});
   const [validationErrors, setValidationErrors] = useState<ValidationErrors>({});
   const [step2ValidationErrors, setStep2ValidationErrors] = useState<Step2ValidationErrors>({});
@@ -310,43 +309,27 @@ export function useChatFeedbackForm(chatId: number) {
     setIsSubmitting(true);
     setSubmitError(null);
 
-    try {
-      await closeChat({ chatId });
-      const payload: ChatFeedbackRequest = _buildPayload({
-        questions: CHAT_FEEDBACK_QUESTIONS,
-        answers,
-        selectedCoreRequirements,
-        step2Evaluations,
-        preferVerboseMultiLabels: false,
-      });
-      try {
-        await createChatFeedback({ chatId, payload });
-      } catch (error) {
-        if (error instanceof BusinessError && error.code === 'FEEDBACK_ANSWER_INVALID') {
-          const retryPayload: ChatFeedbackRequest = _buildPayload({
-            questions: CHAT_FEEDBACK_QUESTIONS,
-            answers,
-            selectedCoreRequirements,
-            step2Evaluations,
-            preferVerboseMultiLabels: true,
-          });
-          await createChatFeedback({ chatId, payload: retryPayload });
-        } else {
-          throw error;
-        }
-      }
-      if (typeof window !== 'undefined') {
-        sessionStorage.setItem('reportCreateSuccess', 'true');
-      }
-      router.replace('/chat');
-    } catch (error) {
-      if (await handleCommonApiError(error)) {
-        return;
-      }
-      setSubmitError(error instanceof Error ? error.message : '설문 제출에 실패했습니다.');
-    } finally {
-      setIsSubmitting(false);
+    const payload: ChatFeedbackRequest = _buildPayload({
+      questions: CHAT_FEEDBACK_QUESTIONS,
+      answers,
+      selectedCoreRequirements,
+      step2Evaluations,
+      preferVerboseMultiLabels: false,
+    });
+    const retryPayload: ChatFeedbackRequest = _buildPayload({
+      questions: CHAT_FEEDBACK_QUESTIONS,
+      answers,
+      selectedCoreRequirements,
+      step2Evaluations,
+      preferVerboseMultiLabels: true,
+    });
+
+    sendFeedbackInBackground(chatId, payload, retryPayload);
+    if (typeof window !== 'undefined') {
+      sessionStorage.setItem('reportCreateSuccess', 'true');
     }
+    setIsSubmitting(false);
+    router.replace('/chat');
   };
 
   return {
@@ -369,6 +352,72 @@ export function useChatFeedbackForm(chatId: number) {
     confirmCustomMultiAnswer,
     handleSubmit,
   };
+}
+
+async function closeChatInBackground(chatId: number): Promise<boolean> {
+  const url = `/bff/chat/${chatId}`;
+  const accessToken = readAccessToken();
+  const headers: HeadersInit = accessToken ? { Authorization: `Bearer ${accessToken}` } : {};
+
+  try {
+    const response = await fetch(url, {
+      method: 'PATCH',
+      credentials: 'include',
+      keepalive: true,
+      headers,
+    });
+    if (!response.ok) return false;
+    const body = (await response.json().catch(() => null)) as { code?: string } | null;
+    return body?.code === 'OK' || body?.code === 'UPDATED';
+  } catch {
+    return false;
+  }
+}
+
+function sendFeedbackInBackground(
+  chatId: number,
+  payload: ChatFeedbackRequest,
+  retryPayload: ChatFeedbackRequest,
+) {
+  const url = `/bff/chat/${chatId}/feedback`;
+
+  const accessToken = readAccessToken();
+  const headers: HeadersInit = accessToken
+    ? { Authorization: `Bearer ${accessToken}`, 'Content-Type': 'application/json' }
+    : { 'Content-Type': 'application/json' };
+
+  const postFeedback = async (requestPayload: ChatFeedbackRequest) => {
+    const response = await fetch(url, {
+      method: 'POST',
+      credentials: 'include',
+      keepalive: true,
+      headers,
+      body: JSON.stringify(requestPayload),
+    }).catch(() => null);
+    if (!response) return { ok: false, code: '' };
+    const data = (await response.json().catch(() => null)) as { code?: string } | null;
+    return { ok: response.ok && data?.code === 'CREATED', code: data?.code ?? '' };
+  };
+
+  void (async () => {
+    const closed = await closeChatInBackground(chatId);
+    if (!closed) return;
+
+    const first = await postFeedback(payload);
+    if (first.ok) {
+      markReportCreateAccepted();
+      return;
+    }
+
+    if (first.code !== 'FEEDBACK_ANSWER_INVALID') {
+      return;
+    }
+
+    const second = await postFeedback(retryPayload);
+    if (second.ok) {
+      markReportCreateAccepted();
+    }
+  })();
 }
 
 function parseCommaValues(value: string | string[] | undefined): string[] {

--- a/src/features/chat/model/useChatHistory.client.ts
+++ b/src/features/chat/model/useChatHistory.client.ts
@@ -2,7 +2,11 @@
 
 import { useCallback, useEffect, useState } from 'react';
 
-import type { ChatMessageItem } from '@/entities/chat';
+import {
+  CHAT_REALTIME_REFRESH_EVENT,
+  type ChatMessageItem,
+  type ChatRealtimeRefreshPayload,
+} from '@/entities/chat';
 import { useCommonApiErrorHandler } from '@/shared/api';
 
 import { getChatMessages } from '../api/getChatMessages';
@@ -64,8 +68,19 @@ export function useChatHistory(chatId: number, currentUserId: number | null) {
 
     loadHistory();
 
+    const handleRealtimeRefresh = (event: Event) => {
+      const customEvent = event as CustomEvent<ChatRealtimeRefreshPayload | undefined>;
+      if (customEvent.detail?.chatId !== chatId) return;
+      void loadHistory();
+    };
+    window.addEventListener(CHAT_REALTIME_REFRESH_EVENT, handleRealtimeRefresh as EventListener);
+
     return () => {
       cancelled = true;
+      window.removeEventListener(
+        CHAT_REALTIME_REFRESH_EVENT,
+        handleRealtimeRefresh as EventListener,
+      );
     };
   }, [chatId, currentUserId, handleCommonApiError]);
 

--- a/src/features/chat/model/useChatList.client.ts
+++ b/src/features/chat/model/useChatList.client.ts
@@ -2,7 +2,12 @@ import { useCallback, useEffect, useRef, useState } from 'react';
 
 import { useAuthStatus } from '@/entities/auth';
 import { useUserMeQuery } from '@/entities/user';
-import type { ChatSummary } from '@/entities/chat';
+import {
+  CHAT_LIST_REFRESH_EVENT,
+  CHAT_REALTIME_REFRESH_EVENT,
+  type ChatRealtimeRefreshPayload,
+  type ChatSummary,
+} from '@/entities/chat';
 import { getChatList } from '@/features/chat';
 import { useCommonApiErrorHandler } from '@/shared/api';
 
@@ -89,13 +94,28 @@ export function useChatList() {
       if (document.visibilityState !== 'visible') return;
       void fetchChats(false);
     };
+    const handleRealtimeRefresh = (event: Event) => {
+      const customEvent = event as CustomEvent<ChatRealtimeRefreshPayload | undefined>;
+      if (!customEvent.detail?.chatId) return;
+      void fetchChats(false);
+    };
+    const handleChatListRefresh = () => {
+      void fetchChats(false);
+    };
 
     window.addEventListener('focus', handleRefresh);
     document.addEventListener('visibilitychange', handleRefresh);
+    window.addEventListener(CHAT_REALTIME_REFRESH_EVENT, handleRealtimeRefresh as EventListener);
+    window.addEventListener(CHAT_LIST_REFRESH_EVENT, handleChatListRefresh);
 
     return () => {
       window.removeEventListener('focus', handleRefresh);
       document.removeEventListener('visibilitychange', handleRefresh);
+      window.removeEventListener(
+        CHAT_REALTIME_REFRESH_EVENT,
+        handleRealtimeRefresh as EventListener,
+      );
+      window.removeEventListener(CHAT_LIST_REFRESH_EVENT, handleChatListRefresh);
     };
   }, [authStatus, fetchChats]);
 

--- a/src/features/chat/model/useChatRoomDetail.client.ts
+++ b/src/features/chat/model/useChatRoomDetail.client.ts
@@ -4,6 +4,7 @@ import { useCallback, useEffect, useState } from 'react';
 import { useRouter } from 'next/navigation';
 
 import { getChatDetail } from '@/features/chat';
+import { CHAT_REALTIME_REFRESH_EVENT, type ChatRealtimeRefreshPayload } from '@/entities/chat';
 import { BusinessError, HttpError, useCommonApiErrorHandler } from '@/shared/api';
 import { useToast } from '@/shared/ui/toast';
 
@@ -33,35 +34,44 @@ export function useChatRoomDetail(chatId: number, currentUserId: number | null) 
     if (!chatId) return;
     let cancelled = false;
 
-    (async () => {
-      const loadDetail = async () => {
-        try {
-          setIsLoading(true);
-          const detail = await getChatDetail({ chatId });
-          if (cancelled) return;
-          const meId = currentUserId;
-          const counterpart =
-            meId !== null && detail.receiver.user_id === meId ? detail.requester : detail.receiver;
-          setHeaderTitle(counterpart.nickname ?? '채팅');
-          setChatStatus(detail.status);
-        } catch (error) {
-          if (cancelled) return;
-          const handled = await handleCommonApiError(error);
-          if (handled) {
-            return;
-          }
-          if (handleInvalidAccess(error)) return;
-          console.warn('Chat detail load failed:', error);
-        } finally {
-          if (!cancelled) setIsLoading(false);
+    const loadDetail = async () => {
+      try {
+        setIsLoading(true);
+        const detail = await getChatDetail({ chatId });
+        if (cancelled) return;
+        const meId = currentUserId;
+        const counterpart =
+          meId !== null && detail.receiver.user_id === meId ? detail.requester : detail.receiver;
+        setHeaderTitle(counterpart.nickname ?? '채팅');
+        setChatStatus(detail.status);
+      } catch (error) {
+        if (cancelled) return;
+        const handled = await handleCommonApiError(error);
+        if (handled) {
+          return;
         }
-      };
+        if (handleInvalidAccess(error)) return;
+        console.warn('Chat detail load failed:', error);
+      } finally {
+        if (!cancelled) setIsLoading(false);
+      }
+    };
 
-      await loadDetail();
-    })();
+    void loadDetail();
+
+    const handleRealtimeRefresh = (event: Event) => {
+      const customEvent = event as CustomEvent<ChatRealtimeRefreshPayload | undefined>;
+      if (customEvent.detail?.chatId !== chatId) return;
+      void loadDetail();
+    };
+    window.addEventListener(CHAT_REALTIME_REFRESH_EVENT, handleRealtimeRefresh as EventListener);
 
     return () => {
       cancelled = true;
+      window.removeEventListener(
+        CHAT_REALTIME_REFRESH_EVENT,
+        handleRealtimeRefresh as EventListener,
+      );
     };
   }, [chatId, currentUserId, handleCommonApiError, handleInvalidAccess]);
 

--- a/src/features/chat/server/createChatFeedback.server.ts
+++ b/src/features/chat/server/createChatFeedback.server.ts
@@ -5,7 +5,8 @@ import { buildApiUrl } from '@/shared/api';
 import { apiFetchWithRefresh } from '@/shared/api/server';
 
 const CHAT_FEEDBACK_PATH = '/api/v2/chats';
-const CHAT_FEEDBACK_TIMEOUT_MS = 30000;
+const REPORTS_PATH = '/api/v2/reports';
+const REPORT_CREATE_TIMEOUT_MS = 30000;
 
 export interface CreateChatFeedbackParams {
   chatId: number;
@@ -17,17 +18,36 @@ export interface CreateChatFeedbackParams {
 export async function createChatFeedback(
   params: CreateChatFeedbackParams,
 ): Promise<ChatFeedbackCreatedData> {
-  const url = buildApiUrl(`${CHAT_FEEDBACK_PATH}/${params.chatId}/feedback`);
+  const feedbackUrl = buildApiUrl(`${CHAT_FEEDBACK_PATH}/${params.chatId}/feedback`);
 
   return apiFetchWithRefresh<ChatFeedbackCreatedData>(
-    url,
+    feedbackUrl,
     {
       method: 'POST',
-      signal: AbortSignal.timeout(CHAT_FEEDBACK_TIMEOUT_MS),
+      signal: AbortSignal.timeout(REPORT_CREATE_TIMEOUT_MS),
       headers: {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify(params.payload),
+    },
+    params.accessToken,
+    params.allowRefresh ?? true,
+  );
+}
+
+export async function requestReportCreate(
+  params: Omit<CreateChatFeedbackParams, 'payload'>,
+): Promise<ChatFeedbackCreatedData> {
+  const reportUrl = buildApiUrl(REPORTS_PATH);
+  return apiFetchWithRefresh<ChatFeedbackCreatedData>(
+    reportUrl,
+    {
+      method: 'POST',
+      signal: AbortSignal.timeout(REPORT_CREATE_TIMEOUT_MS),
+      headers: {
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ chat_room_id: params.chatId }),
     },
     params.accessToken,
     params.allowRefresh ?? true,

--- a/src/features/chat/server/index.ts
+++ b/src/features/chat/server/index.ts
@@ -8,4 +8,4 @@ export { getChatMessages } from './getChatMessages.server';
 export { createChat } from './createChat.server';
 export { markChatRead } from './markChatRead.server';
 export { updateChatLastRead } from './updateChatLastRead.server';
-export { createChatFeedback } from './createChatFeedback.server';
+export { createChatFeedback, requestReportCreate } from './createChatFeedback.server';

--- a/src/features/notification-fcm/model/useEventsSse.client.ts
+++ b/src/features/notification-fcm/model/useEventsSse.client.ts
@@ -1,0 +1,249 @@
+'use client';
+
+import { useEffect } from 'react';
+import { useQueryClient } from '@tanstack/react-query';
+
+import { useAuthStatus } from '@/entities/auth';
+import {
+  CHAT_LIST_REFRESH_EVENT,
+  CHAT_REALTIME_REFRESH_EVENT,
+  parseChatRealtimePayload,
+  type ChatRealtimeRefreshPayload,
+} from '@/entities/chat';
+import { notificationsQueryKey } from '@/entities/notification';
+import { reportsQueryKey } from '@/entities/reports';
+import { resumesQueryKey } from '@/entities/resumes';
+import { buildApiUrl, readAccessToken } from '@/shared/api';
+import {
+  APP_NOTIFICATION_EVENT,
+  type AppNotificationType,
+  type AppNotificationEventDetail,
+} from '@/shared/lib/realtimeNotification.client';
+
+const EVENTS_SUBSCRIBE_PATH = '/api/v2/events/subscribe';
+const SSE_RECONNECT_MIN_MS = 1000;
+const SSE_RECONNECT_MAX_MS = 10000;
+
+type NotificationEventLike = {
+  type?: unknown;
+  notification_type?: unknown;
+  notification_id?: unknown;
+  unread_count?: unknown;
+};
+
+const sleep = (ms: number) => new Promise((resolve) => setTimeout(resolve, ms));
+
+function isNotificationEvent(raw: unknown): raw is NotificationEventLike {
+  if (!raw || typeof raw !== 'object') return false;
+  const event = raw as NotificationEventLike;
+  if (typeof event.type === 'string' && event.type.toUpperCase() === 'NOTIFICATION') return true;
+  return (
+    event.notification_type !== undefined ||
+    event.notification_id !== undefined ||
+    event.unread_count !== undefined
+  );
+}
+
+function dispatchChatRefresh(detail: ChatRealtimeRefreshPayload) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new CustomEvent(CHAT_REALTIME_REFRESH_EVENT, { detail }));
+}
+
+function dispatchChatListRefresh() {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(new Event(CHAT_LIST_REFRESH_EVENT));
+}
+
+function parseNotificationType(raw: unknown): AppNotificationType | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const value = (raw as NotificationEventLike).notification_type;
+  if (typeof value !== 'string') return null;
+  const normalized = value.toUpperCase();
+  if (
+    normalized === 'CHAT_MESSAGE_RECEIVED' ||
+    normalized === 'CHAT_REQUEST_CREATED' ||
+    normalized === 'RESUME_PARSE_COMPLETED' ||
+    normalized === 'RESUME_PARSE_FAILED' ||
+    normalized === 'REPORT_GENERATE_COMPLETED' ||
+    normalized === 'REPORT_GENERATE_FAILED'
+  ) {
+    return normalized;
+  }
+  return null;
+}
+
+function dispatchNotificationEvent(notificationType: AppNotificationType) {
+  if (typeof window === 'undefined') return;
+  window.dispatchEvent(
+    new CustomEvent<AppNotificationEventDetail>(APP_NOTIFICATION_EVENT, {
+      detail: { notificationType },
+    }),
+  );
+}
+
+function handleRealtimeEvent(
+  raw: unknown,
+  invalidateNotifications: () => void,
+  invalidateResumes: () => void,
+  invalidateReports: () => void,
+) {
+  const chatPayload = parseChatRealtimePayload(raw);
+  if (chatPayload) {
+    dispatchChatRefresh(chatPayload);
+    return;
+  }
+
+  if (isNotificationEvent(raw)) {
+    invalidateNotifications();
+    const notificationType = parseNotificationType(raw);
+    if (notificationType) {
+      dispatchNotificationEvent(notificationType);
+    }
+    if (
+      notificationType === 'CHAT_MESSAGE_RECEIVED' ||
+      notificationType === 'CHAT_REQUEST_CREATED'
+    ) {
+      dispatchChatListRefresh();
+      return;
+    }
+    if (
+      notificationType === 'RESUME_PARSE_COMPLETED' ||
+      notificationType === 'RESUME_PARSE_FAILED'
+    ) {
+      invalidateResumes();
+      return;
+    }
+    if (
+      notificationType === 'REPORT_GENERATE_COMPLETED' ||
+      notificationType === 'REPORT_GENERATE_FAILED'
+    ) {
+      invalidateReports();
+    }
+  }
+}
+
+async function consumeSseStream(
+  stream: ReadableStream<Uint8Array>,
+  onEvent: (payload: unknown) => void,
+  signal: AbortSignal,
+) {
+  const reader = stream.getReader();
+  const decoder = new TextDecoder();
+  let buffer = '';
+
+  try {
+    while (!signal.aborted) {
+      const { value, done } = await reader.read();
+      if (done) break;
+      buffer += decoder.decode(value, { stream: true });
+
+      const blocks = buffer.split('\n\n');
+      buffer = blocks.pop() ?? '';
+
+      for (const block of blocks) {
+        const lines = block
+          .split('\n')
+          .map((line) => line.trim())
+          .filter(Boolean);
+        if (lines.length === 0) continue;
+
+        const dataLines = lines
+          .filter((line) => line.startsWith('data:'))
+          .map((line) => line.slice('data:'.length).trim());
+        if (dataLines.length === 0) continue;
+
+        const rawData = dataLines.join('\n');
+        if (!rawData || rawData === '[DONE]') continue;
+
+        try {
+          onEvent(JSON.parse(rawData));
+        } catch {
+          // ignore malformed event payload
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+export function useEventsSse() {
+  const { status } = useAuthStatus();
+  const queryClient = useQueryClient();
+
+  useEffect(() => {
+    if (status !== 'authed') return;
+
+    let cancelled = false;
+    let controller: AbortController | null = null;
+
+    const invalidateNotifications = () => {
+      void queryClient.invalidateQueries({ queryKey: notificationsQueryKey });
+    };
+    const invalidateResumes = () => {
+      void queryClient.invalidateQueries({ queryKey: resumesQueryKey });
+    };
+    const invalidateReports = () => {
+      void queryClient.invalidateQueries({ queryKey: reportsQueryKey });
+    };
+
+    const run = async () => {
+      let reconnectDelayMs = SSE_RECONNECT_MIN_MS;
+
+      while (!cancelled) {
+        const accessToken = readAccessToken();
+        if (!accessToken) {
+          await sleep(SSE_RECONNECT_MIN_MS);
+          continue;
+        }
+
+        controller = new AbortController();
+
+        try {
+          const response = await fetch(buildApiUrl(EVENTS_SUBSCRIBE_PATH), {
+            method: 'GET',
+            headers: {
+              Accept: 'text/event-stream',
+              Authorization: `Bearer ${accessToken}`,
+            },
+            credentials: 'include',
+            cache: 'no-store',
+            signal: controller.signal,
+          });
+
+          if (!response.ok || !response.body) {
+            throw new Error(`SSE_CONNECT_FAILED_${response.status}`);
+          }
+
+          reconnectDelayMs = SSE_RECONNECT_MIN_MS;
+          await consumeSseStream(
+            response.body,
+            (payload) =>
+              handleRealtimeEvent(
+                payload,
+                invalidateNotifications,
+                invalidateResumes,
+                invalidateReports,
+              ),
+            controller.signal,
+          );
+        } catch {
+          // silent reconnect
+        } finally {
+          controller = null;
+        }
+
+        if (cancelled) break;
+        await sleep(reconnectDelayMs);
+        reconnectDelayMs = Math.min(reconnectDelayMs * 2, SSE_RECONNECT_MAX_MS);
+      }
+    };
+
+    void run();
+
+    return () => {
+      cancelled = true;
+      controller?.abort();
+    };
+  }, [queryClient, status]);
+}

--- a/src/features/notification-fcm/model/useFcmLifecycle.client.ts
+++ b/src/features/notification-fcm/model/useFcmLifecycle.client.ts
@@ -6,7 +6,6 @@ import { useQueryClient } from '@tanstack/react-query';
 
 import { deleteFcmToken, notificationsQueryKey, registerFcmToken } from '@/entities/notification';
 import { getFirebaseMessaging } from '@/shared/lib/firebase';
-import { useToast } from '@/shared/ui/toast';
 
 const FCM_STORAGE_KEY = 'refit.fcm.token';
 const IOS_USER_AGENT_REGEX = /iphone|ipad|ipod/i;
@@ -48,7 +47,6 @@ function isStandalonePwa() {
 
 export function useFcmLifecycle() {
   const queryClient = useQueryClient();
-  const { pushToast } = useToast();
 
   const initFcm = useCallback(async ({ requestPermission = true }: InitFcmOptions = {}) => {
     if (typeof window === 'undefined' || !('Notification' in window)) return;
@@ -99,11 +97,7 @@ export function useFcmLifecycle() {
       .then((messaging) => {
         if (!messaging || isCleanedUp) return;
         unsubscribe = onMessage(messaging, (payload) => {
-          const title = payload.notification?.title;
-          const body = payload.notification?.body;
-          if (title || body) {
-            pushToast([title, body].filter(Boolean).join(' - '), { variant: 'success' });
-          }
+          void payload;
           queryClient.invalidateQueries({ queryKey: notificationsQueryKey });
         });
       })
@@ -113,7 +107,7 @@ export function useFcmLifecycle() {
       isCleanedUp = true;
       unsubscribe?.();
     };
-  }, [pushToast, queryClient]);
+  }, [queryClient]);
 
   return { initFcm, listenForeground };
 }

--- a/src/features/notification-fcm/ui/FcmBootstrap.client.tsx
+++ b/src/features/notification-fcm/ui/FcmBootstrap.client.tsx
@@ -4,10 +4,12 @@ import { useEffect, useRef } from 'react';
 
 import { useAuthStatus } from '@/entities/auth';
 import { useFcmLifecycle } from '../model/useFcmLifecycle.client';
+import { useEventsSse } from '../model/useEventsSse.client';
 
 export default function FcmBootstrap() {
   const { status } = useAuthStatus();
   const { initFcm, listenForeground } = useFcmLifecycle();
+  useEventsSse();
   const initializedRef = useRef(false);
 
   useEffect(() => {

--- a/src/features/report/model/useReportList.client.ts
+++ b/src/features/report/model/useReportList.client.ts
@@ -1,6 +1,6 @@
 'use client';
 
-import { useEffect, useMemo, useState } from 'react';
+import { useCallback, useEffect, useMemo, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
 import { useAuthStatus } from '@/entities/auth';
@@ -22,7 +22,7 @@ export function useReportList() {
   const [isDeletingId, setIsDeletingId] = useState<number | null>(null);
   const [openMenuId, setOpenMenuId] = useState<number | null>(null);
   const queryClient = useQueryClient();
-  const { data, error, isLoading } = useReportsQuery({ enabled: authStatus === 'authed' });
+  const { data, error, isLoading, refetch } = useReportsQuery({ enabled: authStatus === 'authed' });
 
   useEffect(() => {
     if (authStatus !== 'authed') {
@@ -55,6 +55,29 @@ export function useReportList() {
     if (reports.some((report) => report.reportId === openMenuId)) return;
     setOpenMenuId(null);
   }, [openMenuId, reports]);
+
+  const refreshReports = useCallback(() => {
+    if (authStatus !== 'authed') return;
+    void refetch();
+  }, [authStatus, refetch]);
+
+  useEffect(() => {
+    if (authStatus !== 'authed') return;
+    refreshReports();
+
+    const handleFocusRefresh = () => {
+      if (document.visibilityState !== 'visible') return;
+      refreshReports();
+    };
+
+    window.addEventListener('focus', handleFocusRefresh);
+    document.addEventListener('visibilitychange', handleFocusRefresh);
+
+    return () => {
+      window.removeEventListener('focus', handleFocusRefresh);
+      document.removeEventListener('visibilitychange', handleFocusRefresh);
+    };
+  }, [authStatus, refreshReports]);
 
   const handleDeleteReport = async (reportId: number) => {
     if (isDeletingId) return;

--- a/src/features/resume/lib/resumeParsePending.client.ts
+++ b/src/features/resume/lib/resumeParsePending.client.ts
@@ -1,0 +1,43 @@
+'use client';
+
+export type PendingResumeParseTask = {
+  taskId: string;
+  fileUrl: string;
+  createdAt: string;
+};
+
+const STORAGE_KEY = 'resumeParsePendingTasks';
+
+function canUseStorage() {
+  return typeof window !== 'undefined' && typeof sessionStorage !== 'undefined';
+}
+
+export function readPendingResumeParseTasks(): PendingResumeParseTask[] {
+  if (!canUseStorage()) return [];
+  try {
+    const raw = sessionStorage.getItem(STORAGE_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw) as PendingResumeParseTask[];
+    if (!Array.isArray(parsed)) return [];
+    return parsed.filter(
+      (item) =>
+        typeof item?.taskId === 'string' &&
+        item.taskId.length > 0 &&
+        typeof item.fileUrl === 'string' &&
+        typeof item.createdAt === 'string',
+    );
+  } catch {
+    return [];
+  }
+}
+
+export function writePendingResumeParseTasks(tasks: PendingResumeParseTask[]) {
+  if (!canUseStorage()) return;
+  sessionStorage.setItem(STORAGE_KEY, JSON.stringify(tasks));
+}
+
+export function addPendingResumeParseTask(task: PendingResumeParseTask) {
+  const current = readPendingResumeParseTasks();
+  const withoutSame = current.filter((item) => item.taskId !== task.taskId);
+  writePendingResumeParseTasks([task, ...withoutSame]);
+}

--- a/src/features/resume/model/useResumeAutoFill.client.ts
+++ b/src/features/resume/model/useResumeAutoFill.client.ts
@@ -1,19 +1,21 @@
 'use client';
 
 import { useState } from 'react';
+import { useRouter } from 'next/navigation';
 
 import { createPresignedUrl, uploadToPresignedUrl } from '@/features/uploads';
-import { parseResumeSync, type ResumeParseSyncResult } from '@/entities/resumes';
+import { parseResumeTask } from '@/entities/resumes';
 import { useCommonApiErrorHandler } from '@/shared/api';
+import { addPendingResumeParseTask } from '../lib/resumeParsePending.client';
 
 export const MAX_RESUME_PDF_SIZE = 5 * 1024 * 1024;
 
 type UseResumeAutoFillParams = {
   authStatus: 'checking' | 'authed' | 'guest';
-  onParsed: (result: ResumeParseSyncResult | null) => boolean;
 };
 
-export function useResumeAutoFill({ authStatus, onParsed }: UseResumeAutoFillParams) {
+export function useResumeAutoFill({ authStatus }: UseResumeAutoFillParams) {
+  const router = useRouter();
   const handleCommonApiError = useCommonApiErrorHandler({ redirectTo: '/resume' });
   const [autoFillError, setAutoFillError] = useState<string | null>(null);
   const [isAutoFilling, setIsAutoFilling] = useState(false);
@@ -40,11 +42,17 @@ export function useResumeAutoFill({ authStatus, onParsed }: UseResumeAutoFillPar
           file_size: file.size,
         });
         await uploadToPresignedUrl(file, presignedUrl);
-        const data = await parseResumeSync({ file_url: uploadedUrl, mode: 'sync' });
-        const applied = onParsed(data.result);
-        if (!applied) {
-          setAutoFillError('이력서 자동 등록에 실패했습니다.');
+
+        const parseTask = await parseResumeTask({ file_url: uploadedUrl });
+        if (parseTask.taskId) {
+          addPendingResumeParseTask({
+            taskId: parseTask.taskId,
+            fileUrl: uploadedUrl,
+            createdAt: new Date().toISOString(),
+          });
         }
+        router.replace('/resume');
+        return;
       } catch (error) {
         if (await handleCommonApiError(error)) {
           setIsAutoFilling(false);

--- a/src/features/resume/model/useResumeEdit.client.ts
+++ b/src/features/resume/model/useResumeEdit.client.ts
@@ -32,7 +32,7 @@ export function useResumeEdit(resumeIdParam: string | null) {
       submit.setSubmitError(message);
     },
   });
-  const autoFill = useResumeAutoFill({ authStatus, onParsed: form.applyParsedResult });
+  const autoFill = useResumeAutoFill({ authStatus });
 
   return {
     authStatus,

--- a/src/features/resume/model/useResumeEditForm.client.ts
+++ b/src/features/resume/model/useResumeEditForm.client.ts
@@ -5,7 +5,7 @@ import { useCallback, useMemo, useState } from 'react';
 import type {
   ResumeDetail,
   ResumeParseContentJson,
-  ResumeParseSyncResult,
+  ResumeParseTaskResult,
 } from '@/entities/resumes';
 
 export type CareerItem = {
@@ -254,8 +254,25 @@ export function useResumeEditForm() {
   );
 
   const applyParsedResult = useCallback(
-    (result: ResumeParseSyncResult | null) => {
-      if (!result) return false;
+    (
+      result: ResumeParseTaskResult | null,
+      context?: { fileUrl: string; status: string; taskId: string },
+    ) => {
+      if (context?.fileUrl) {
+        setFileUrl(context.fileUrl);
+      }
+
+      if (!result) {
+        // V2 비동기 파싱은 초기 응답에서 result가 비어있을 수 있어 필수 입력값만 기본 채움.
+        setIsFresher(false);
+        setEducation([{ id: education[0]?.id ?? createId(), value: educationOptions[0] }]);
+        setCareers([{ id: createId(), company: '', period: '', role: '', title: '' }]);
+        setProjects([{ id: createId(), title: '', period: '', description: '' }]);
+        setAwards([{ id: createId(), value: '' }]);
+        setCertificates([{ id: createId(), value: '' }]);
+        setActivities([{ id: createId(), value: '' }]);
+        return true;
+      }
 
       const contentJson = (result.content_json ?? {}) as ResumeParseContentJson;
       const careersValue = Array.isArray(contentJson.careers) ? contentJson.careers : [];
@@ -277,6 +294,8 @@ export function useResumeEditForm() {
           : null;
       if (mappedEducation) {
         setEducation([{ id: education[0]?.id ?? createId(), value: mappedEducation }]);
+      } else {
+        setEducation([{ id: education[0]?.id ?? createId(), value: educationOptions[0] }]);
       }
 
       setCareers(normalizeCareerItems(careersValue));

--- a/src/features/resume/model/useResumeList.client.ts
+++ b/src/features/resume/model/useResumeList.client.ts
@@ -1,29 +1,63 @@
-import { useEffect, useState } from 'react';
+import { useCallback, useEffect, useRef, useState } from 'react';
 import { useQueryClient } from '@tanstack/react-query';
 
-import { deleteResume, resumesQueryKey, useResumesQuery, type Resume } from '@/entities/resumes';
+import {
+  createResume,
+  deleteResume,
+  getResumeParseTask,
+  resumesQueryKey,
+  useResumesQuery,
+  type Resume,
+  type ResumeParseTaskResult,
+} from '@/entities/resumes';
 import { useAuthStatus } from '@/entities/auth';
 import { useCommonApiErrorHandler } from '@/shared/api';
+import {
+  APP_NOTIFICATION_EVENT,
+  type AppNotificationEventDetail,
+} from '@/shared/lib/realtimeNotification.client';
+import {
+  readPendingResumeParseTasks,
+  writePendingResumeParseTasks,
+  type PendingResumeParseTask,
+} from '../lib/resumeParsePending.client';
+
+const DEFAULT_EDUCATION_LEVEL = '4년제 졸업';
+const DEFAULT_AUTO_TITLE = '자동 생성 이력서';
 
 export function useResumeList() {
   const { status: authStatus } = useAuthStatus();
   const handleCommonApiError = useCommonApiErrorHandler();
   const [resumes, setResumes] = useState<Resume[]>([]);
+  const [pendingTasks, setPendingTasks] = useState<PendingResumeParseTask[]>([]);
   const [isLoadingResumes, setIsLoadingResumes] = useState(false);
   const [loadError, setLoadError] = useState<string | null>(null);
   const [openMenuId, setOpenMenuId] = useState<number | null>(null);
   const [isDeletingId, setIsDeletingId] = useState<number | null>(null);
+  const pendingTasksRef = useRef<PendingResumeParseTask[]>([]);
+  const handlingTaskIdsRef = useRef<Set<string>>(new Set());
   const queryClient = useQueryClient();
-  const { data, error, isLoading } = useResumesQuery({ enabled: authStatus === 'authed' });
+  const { data, error, isLoading, refetch } = useResumesQuery({ enabled: authStatus === 'authed' });
 
   useEffect(() => {
     if (authStatus !== 'authed') {
       setLoadError(null);
       setResumes([]);
+      setPendingTasks([]);
       return;
     }
     setResumes(data?.resumes ?? []);
   }, [authStatus, data]);
+
+  useEffect(() => {
+    if (authStatus !== 'authed') {
+      pendingTasksRef.current = [];
+      return;
+    }
+    const stored = readPendingResumeParseTasks();
+    setPendingTasks(stored);
+    pendingTasksRef.current = stored;
+  }, [authStatus]);
 
   useEffect(() => {
     if (!error) {
@@ -45,6 +79,131 @@ export function useResumeList() {
     if (resumes.some((item) => item.resumeId === openMenuId)) return;
     setOpenMenuId(null);
   }, [openMenuId, resumes]);
+
+  const updatePendingTasks = useCallback(
+    (updater: (prev: PendingResumeParseTask[]) => PendingResumeParseTask[]) => {
+      setPendingTasks((prev) => {
+        const next = updater(prev);
+        pendingTasksRef.current = next;
+        writePendingResumeParseTasks(next);
+        return next;
+      });
+    },
+    [],
+  );
+
+  const removePendingTask = useCallback(
+    (taskId: string) => {
+      updatePendingTasks((prev) => prev.filter((task) => task.taskId !== taskId));
+    },
+    [updatePendingTasks],
+  );
+
+  const createResumeFromParseResult = useCallback(
+    async (taskId: string, result: ResumeParseTaskResult | null | undefined) => {
+      if (handlingTaskIdsRef.current.has(taskId)) return;
+      handlingTaskIdsRef.current.add(taskId);
+
+      const task = pendingTasksRef.current.find((item) => item.taskId === taskId);
+      if (!task) {
+        handlingTaskIdsRef.current.delete(taskId);
+        return;
+      }
+
+      try {
+        const rawEducation = result?.education_level ?? result?.educationLevel;
+        const educationLevel =
+          typeof rawEducation === 'string' && rawEducation.trim()
+            ? rawEducation.trim()
+            : DEFAULT_EDUCATION_LEVEL;
+        const rawContent = result?.content_json ?? result?.contentJson;
+        const contentJson =
+          rawContent && typeof rawContent === 'object' && !Array.isArray(rawContent)
+            ? (rawContent as Record<string, unknown>)
+            : {};
+        const rawIsFresher = result?.is_fresher ?? result?.isFresher;
+
+        await createResume({
+          title: DEFAULT_AUTO_TITLE,
+          is_fresher: typeof rawIsFresher === 'boolean' ? rawIsFresher : false,
+          education_level: educationLevel,
+          file_url: task.fileUrl || null,
+          content_json: contentJson,
+        });
+        await queryClient.invalidateQueries({ queryKey: resumesQueryKey });
+      } catch (error) {
+        await handleCommonApiError(error);
+      } finally {
+        removePendingTask(taskId);
+        handlingTaskIdsRef.current.delete(taskId);
+      }
+    },
+    [handleCommonApiError, queryClient, removePendingTask],
+  );
+
+  const syncPendingTasks = useCallback(async () => {
+    if (authStatus !== 'authed') return;
+    const tasks = pendingTasksRef.current;
+    if (!tasks.length) return;
+
+    await Promise.all(
+      tasks.map(async (task) => {
+        try {
+          const taskData = await getResumeParseTask(task.taskId);
+          if (taskData.status === 'FAILED') {
+            removePendingTask(task.taskId);
+            return;
+          }
+          if (taskData.status === 'COMPLETED') {
+            await createResumeFromParseResult(task.taskId, taskData.result);
+          }
+        } catch (error) {
+          await handleCommonApiError(error);
+        }
+      }),
+    );
+  }, [authStatus, createResumeFromParseResult, handleCommonApiError, removePendingTask]);
+
+  const refreshResumes = useCallback(() => {
+    if (authStatus !== 'authed') return;
+    void refetch();
+  }, [authStatus, refetch]);
+
+  useEffect(() => {
+    if (authStatus !== 'authed') return;
+    refreshResumes();
+    void syncPendingTasks();
+
+    const handleFocusRefresh = () => {
+      if (document.visibilityState !== 'visible') return;
+      refreshResumes();
+      void syncPendingTasks();
+    };
+
+    const handleRealtimeNotification = (event: Event) => {
+      const detail = (event as CustomEvent<AppNotificationEventDetail>).detail;
+      if (!detail?.notificationType) return;
+      if (
+        detail.notificationType === 'RESUME_PARSE_COMPLETED' ||
+        detail.notificationType === 'RESUME_PARSE_FAILED'
+      ) {
+        void syncPendingTasks();
+      }
+    };
+
+    window.addEventListener('focus', handleFocusRefresh);
+    document.addEventListener('visibilitychange', handleFocusRefresh);
+    window.addEventListener(APP_NOTIFICATION_EVENT, handleRealtimeNotification as EventListener);
+
+    return () => {
+      window.removeEventListener('focus', handleFocusRefresh);
+      document.removeEventListener('visibilitychange', handleFocusRefresh);
+      window.removeEventListener(
+        APP_NOTIFICATION_EVENT,
+        handleRealtimeNotification as EventListener,
+      );
+    };
+  }, [authStatus, refreshResumes, syncPendingTasks]);
 
   const handleDeleteResume = async (resumeId: number) => {
     if (isDeletingId) return;
@@ -68,6 +227,7 @@ export function useResumeList() {
   return {
     authStatus,
     resumes,
+    pendingTasks,
     isLoadingResumes,
     loadError,
     openMenuId,

--- a/src/shared/lib/realtimeNotification.client.ts
+++ b/src/shared/lib/realtimeNotification.client.ts
@@ -1,0 +1,15 @@
+'use client';
+
+export const APP_NOTIFICATION_EVENT = 'app:notification';
+
+export type AppNotificationType =
+  | 'CHAT_MESSAGE_RECEIVED'
+  | 'CHAT_REQUEST_CREATED'
+  | 'RESUME_PARSE_COMPLETED'
+  | 'RESUME_PARSE_FAILED'
+  | 'REPORT_GENERATE_COMPLETED'
+  | 'REPORT_GENERATE_FAILED';
+
+export type AppNotificationEventDetail = {
+  notificationType: AppNotificationType;
+};

--- a/src/widgets/chat/ui/ChatList.tsx
+++ b/src/widgets/chat/ui/ChatList.tsx
@@ -12,10 +12,7 @@ import { normalizeRequestTypeFromUnknown, type ChatSummary } from '@/entities/ch
 import { AuthGateSheet } from '@/shared/ui/auth-gate';
 import { Modal } from '@/shared/ui/modal';
 import { useToast } from '@/shared/ui/toast';
-import {
-  consumeReportCreateAccepted,
-  REPORT_CREATE_ACCEPTED_EVENT,
-} from '@/features/chat';
+import { consumeReportCreateAccepted, REPORT_CREATE_ACCEPTED_EVENT } from '@/features/chat';
 import charIcon from '@/shared/icons/char_icon.png';
 import ChatRequestSuccessAnimation from './ChatRequestSuccessAnimation';
 import ReportCreateSuccessAnimation from './ReportCreateSuccessAnimation';

--- a/src/widgets/chat/ui/ChatList.tsx
+++ b/src/widgets/chat/ui/ChatList.tsx
@@ -12,6 +12,10 @@ import { normalizeRequestTypeFromUnknown, type ChatSummary } from '@/entities/ch
 import { AuthGateSheet } from '@/shared/ui/auth-gate';
 import { Modal } from '@/shared/ui/modal';
 import { useToast } from '@/shared/ui/toast';
+import {
+  consumeReportCreateAccepted,
+  REPORT_CREATE_ACCEPTED_EVENT,
+} from '@/features/chat';
 import charIcon from '@/shared/icons/char_icon.png';
 import ChatRequestSuccessAnimation from './ChatRequestSuccessAnimation';
 import ReportCreateSuccessAnimation from './ReportCreateSuccessAnimation';
@@ -133,6 +137,19 @@ export default function ChatList() {
     }
     setActiveTab('chats');
   }, [currentUser?.user_type, searchParams]);
+
+  useEffect(() => {
+    const showIfAccepted = () => {
+      if (!consumeReportCreateAccepted()) return;
+      pushToast('레포트 생성이 시작되었습니다. 완료 후 확인해 주세요.', { variant: 'success' });
+    };
+
+    showIfAccepted();
+    window.addEventListener(REPORT_CREATE_ACCEPTED_EVENT, showIfAccepted);
+    return () => {
+      window.removeEventListener(REPORT_CREATE_ACCEPTED_EVENT, showIfAccepted);
+    };
+  }, [pushToast]);
 
   const [requestActionLoading, setRequestActionLoading] = useState<Record<number, boolean>>({});
 

--- a/src/widgets/report/ui/ReportPage.tsx
+++ b/src/widgets/report/ui/ReportPage.tsx
@@ -93,7 +93,7 @@ export default function ReportPage() {
                       {report.title}
                     </p>
                     <p className="mt-2 inline-flex rounded-full bg-[#edf4ff] px-2.5 py-1 text-[11px] font-semibold text-[#35558b]">
-                      REPORT
+                      {report.status?.toUpperCase() === 'PROCESSING' ? 'PROCESSING' : 'REPORT'}
                     </p>
                     <p className="mt-2 text-xs text-[#6b7b92]">
                       {new Date(report.updatedAt).toLocaleDateString('ko-KR')} 업데이트

--- a/src/widgets/resume/ui/ResumePage.tsx
+++ b/src/widgets/resume/ui/ResumePage.tsx
@@ -16,6 +16,7 @@ export default function ResumePage() {
   const {
     authStatus,
     resumes,
+    pendingTasks,
     isLoadingResumes,
     loadError,
     openMenuId,
@@ -49,7 +50,7 @@ export default function ResumePage() {
             피드백 준비를 빠르게 진행하세요
           </p>
           <div className="mt-4 inline-flex rounded-full border border-white/30 bg-white/15 px-3 py-1 text-xs font-semibold">
-            총 {resumes.length}개
+            총 {resumes.length + pendingTasks.length}개
           </div>
         </div>
 
@@ -86,7 +87,7 @@ export default function ResumePage() {
               <span className="text-xl text-[#7f8ea4]">›</span>
             </button>
 
-            {resumes.length === 0 ? (
+            {resumes.length === 0 && pendingTasks.length === 0 ? (
               <div className="mt-6 flex flex-1 items-center justify-center">
                 <Image
                   src={charResume}
@@ -97,6 +98,33 @@ export default function ResumePage() {
               </div>
             ) : (
               <div className="mt-6 flex flex-col gap-3">
+                {pendingTasks.map((task) => (
+                  <div
+                    key={task.taskId}
+                    className="relative rounded-2xl border border-[#dde5ef] bg-white px-5 py-4 shadow-[0_14px_32px_rgba(23,33,52,0.08)]"
+                  >
+                    <div
+                      aria-hidden="true"
+                      className="absolute bottom-3 left-3 top-3 w-1.5 rounded-full bg-gradient-to-b from-[#9aa7b8] to-[#c7d0db]"
+                    />
+                    <div className="w-full pl-4 text-left">
+                      <div className="flex items-start justify-between gap-3">
+                        <div>
+                          <p className="text-[15px] font-semibold text-[#1f2f46]">이력서 생성 중</p>
+                          <p className="mt-2 inline-flex rounded-full bg-[#f2f4f7] px-2.5 py-1 text-[11px] font-semibold text-[#5f6f85]">
+                            PROCESSING
+                          </p>
+                        </div>
+                      </div>
+                      <p className="mt-2 text-xs text-[#6b7b92]">
+                        AI가 이력서를 생성하고 있습니다.
+                      </p>
+                    </div>
+                    <p className="mt-2 pl-4 text-xs text-[#6b7b92]">
+                      {new Date(task.createdAt).toLocaleDateString('ko-KR')} 요청
+                    </p>
+                  </div>
+                ))}
                 {resumes.map((resume) => (
                   <div
                     key={resume.resumeId}
@@ -122,7 +150,9 @@ export default function ResumePage() {
                         <div>
                           <p className="text-[15px] font-semibold text-[#1f2f46]">{resume.title}</p>
                           <p className="mt-2 inline-flex rounded-full bg-[#edf4ff] px-2.5 py-1 text-[11px] font-semibold text-[#35558b]">
-                            RESUME
+                            {resume.status?.toUpperCase() === 'PROCESSING'
+                              ? 'PROCESSING'
+                              : 'RESUME'}
                           </p>
                         </div>
                         <div className="flex items-start gap-2">


### PR DESCRIPTION
## 📌 변경 사항
- 이력서 자동 파싱을 비동기 흐름으로 정리하고, `생성중` 상태 관리/표시를 복구했습니다.
- 파싱 완료 시 이력서를 자동 생성하도록 연결했고, 실패 시 `생성중` 항목을 정리합니다.
- 전역 SSE(`/api/v2/events/subscribe`) 구독을 추가해 알림 타입 기반으로 채팅/이력서/리포트 갱신을 트리거합니다.
- 채팅 피드백 제출 후 리포트 생성을 비동기 트리거로 전환해 사용자 대기 시간을 줄였습니다.
- 채팅 목록/리포트 목록의 포커스 복귀 재조회 및 `PROCESSING` 상태 표시를 보강했습니다.
- FCM 포그라운드 토스트 중복/노이즈를 줄이고, SW에서 중복 알림/`task_id` 노출을 완화했습니다.

## 🔍 상세 내용
- 이력서:
  - 업로드 후 파싱 `taskId`를 세션에 저장하고 리스트로 즉시 이동.
  - 리스트 진입/포커스/`RESUME_PARSE_COMPLETED|FAILED` 알림 수신 시 pending task 상태를 조회해 완료면 `createResume`, 실패면 제거.
  - 파싱 결과 값이 비어 있으면 기본값(`학력: 4년제 졸업`, 제목 더미)으로 생성.
- 실시간:
  - SSE payload를 공용 앱 이벤트로 브로드캐스트해 기능별 훅에서 재조회 트리거로 사용.
  - 기존 개별 화면 의존을 줄이고 “알림 수신 → 필요한 쿼리 invalidate/재조회” 구조로 통일.
- 리포트:
  - 피드백 API 응답은 빠르게 반환하고, 리포트 생성은 백그라운드에서 요청.
  - 채팅 리스트에서 비동기 생성 시작 토스트를 1회성으로 표시.



## ✅ 체크리스트
- [X] 기능이 정상적으로 동작하는지 확인했습니다.
- [X] 기존 기능에 영향을 주지 않는지 확인했습니다.

## 👀 리뷰 요청 사항
  - `taskId` 저장/제거 타이밍과 중복 생성 방지(`handlingTaskIds`) 동작
  - SSE 이벤트 타입 매핑(`RESUME_PARSE_*`, `REPORT_GENERATE_*`) 정확성
  - 피드백 제출 후 리포트 생성 실패 시 사용자 경험(재시도/표시) 정책

## 📎 참고 자료 (선택)
- 추가로 참고해야 할 내용이나 스크린샷이 있다면 작성해 주세요.
